### PR TITLE
Renaming, docs and CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
     - name: Codecov
       uses: codecov/codecov-action@v3
       with:
-        token: ${{ secrets.CODECOV}}
         files: coverage.xml
         fail_ci_if_error: false
         verbose: true

--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -1,0 +1,140 @@
+====================================
+Contributor Covenant Code of Conduct
+====================================
+
+Our Pledge
+==========
+
+We as members, contributors, and leaders pledge to make participation in this
+project and our community a harassment-free experience for everyone, regardless
+of age, body size, visible or invisible disability, ethnicity, sex
+characteristics, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+Our Standards
+=============
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+Enforcement Responsibilities
+============================
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+Scope
+=====
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+Enforcement
+===========
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at oss-coc@vmware.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+Enforcement Guidelines
+======================
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+1. Correction
+-------------
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+2. Warning
+----------
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+3. Temporary Ban
+----------------
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+4. Permanent Ban
+----------------
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+Attribution
+===========
+
+This Code of Conduct is adapted from the `Contributor Covenant`_,
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by `Mozilla's code of conduct
+enforcement ladder <https://github.com/mozilla/diversity>`_.
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+.. _Contributor Covenant: https://www.contributor-covenant.org

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,40 @@
+==============================================
+Contributing to Repository Service for TUF CLI
+==============================================
+
+We welcome contributions from the community and first want to thank you for
+taking the time to contribute!
+
+Please familiarize yourself with the `Code of Conduct`_
+before contributing.
+
+DCO
+===
+
+Before you start working with Repository Service for TUF, please read our
+`Developer Certificate of Origin <https://cla.vmware.com/dco>`_.
+All contributions to this repository must be signed as described on that page.
+
+To acknowledge the Developer Certificate of Origin (DCO), sign your commits
+by appending a ``Signed-off-by:
+Your Name <example@domain.com>`` to each git commit message (see `git commit
+--signoff <https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff>`_).
+Your signature certifies that you wrote the patch or have the right to pass it
+on as an open-source patch.
+
+Getting started
+===============
+
+We welcome many different types of contributions and not all of them need a
+Pull Request. Contributions may include:
+
+* New features and proposals
+* Documentation
+* Bug fixes
+* Issue Triage
+* Answering questions and giving feedback
+* Helping to onboard new contributors
+* Other related activities
+
+
+Check `README.rst <README.rst>`_ development section instructions.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022, Kairo de Araujo
+Copyright (c) 2022, VMware Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.rst
+++ b/README.rst
@@ -4,10 +4,10 @@ Repository Service for TUF Command Line Interface
 
 |Tests and Lint| |Coverage|
 
-.. |Tests and Lint| image:: https://github.com/kaprien/repository-service-tuf-cli/actions/workflows/ci.yml/badge.svg
-  :target: https://github.com/kaprien/repository-service-tuf-cli/actions/workflows/ci.yml
-.. |Coverage| image:: https://codecov.io/gh/kaprien/repository-service-tuf-cli/branch/main/graph/badge.svg
-  :target: https://codecov.io/gh/kaprien/repository-service-tuf-cli
+.. |Tests and Lint| image:: https://github.com/vmware/repository-service-tuf-cli/actions/workflows/ci.yml/badge.svg
+  :target: https://github.com/vmware/repository-service-tuf-cli/actions/workflows/ci.yml
+.. |Coverage| image:: https://codecov.io/gh/vmware/repository-service-tuf-cli/branch/main/graph/badge.svg
+  :target: https://codecov.io/gh/vmware/repository-service-tuf-cli
 
 Repository Service for TUF Command Line Interface (CLI).
 
@@ -30,7 +30,7 @@ Getting the source code
 =======================
 
 `Fork <https://docs.github.com/en/get-started/quickstart/fork-a-repo>`_ the
-repository on `GitHub <https://github.com/kaprien/repository-service-tuf-cli>`_ and
+repository on `GitHub <https://github.com/vmware/repository-service-tuf-cli>`_ and
 `clone <https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository>`_
 it to your local machine:
 
@@ -45,7 +45,7 @@ you stay up-to-date with our repository:
 
 .. code-block:: console
 
-    git remote add upstream https://github.com/kaprien/repository-service-tuf-cli
+    git remote add upstream https://github.com/vmware/repository-service-tuf-cli
     git checkout main
     git fetch upstream
     git merge upstream/main

--- a/tests/unit/cli/admin/test_ceremony.py
+++ b/tests/unit/cli/admin/test_ceremony.py
@@ -301,7 +301,7 @@ class TestCeremonyGroupCLI:
             "",
             "",
             "y",
-            "https://github.com/kaprien",
+            "https://github.com/vmware",
             "*, */*, */*/*, */*/*/*, */*/*/*/*, */*/*/*/*/*",
             "",
             "",


### PR DESCRIPTION
- Rename giving the new github organization
- Add some development docs and Licensing
- Update the CI/CD

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>