### PR TITLE
Add parameter for CLI to show version

### DIFF
--- a/repository_service_tuf/cli/__init__.py
+++ b/repository_service_tuf/cli/__init__.py
@@ -1,13 +1,29 @@
 import importlib
 import os
 import pkgutil
+import re
 from pathlib import Path
 
 import rich_click as click  # type: ignore
 
 from repository_service_tuf import Dynaconf
+from repository_service_tuf.__version__ import version
 
 HOME = str(Path.home())
+
+# attempt to find the program name from pyproject.toml or give a default
+prog_name = "rstuf"
+try:
+    with open("pyproject.toml") as file:
+        for line in file:
+            match = re.search("repository_service_tuf.cli:rstuf", line)
+
+            if match:
+                prog_name = line.split("=")[0].strip()
+                break
+
+except FileNotFoundError:
+    pass
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
@@ -19,6 +35,8 @@ HOME = str(Path.home())
     help="Repository Service for TUF config file",
     required=False,
 )
+# adds the --version parameter
+@click.version_option(prog_name=prog_name, version=version)
 @click.pass_context
 def rstuf(context, config):
     """

--- a/tests/test_tuf_repository_service.py
+++ b/tests/test_tuf_repository_service.py
@@ -1,3 +1,4 @@
+from repository_service_tuf.__version__ import version
 from repository_service_tuf.cli import rstuf
 
 
@@ -6,3 +7,11 @@ class TestRSTUFCLI:
 
         test_result = client.invoke(rstuf)
         assert test_result.exit_code == 0
+
+    def test_trs_version_parameter(self, client):
+        """Tests the CLI --version parameter existence and output format."""
+
+        result = client.invoke(rstuf, ["--version"])
+
+        assert result.exit_code == 0
+        assert result.output == f"rstuf, version {version}\n"


### PR DESCRIPTION
- We added the parameter ```--version``` that shows the ```rstuf``` version.

- Added a check to make sure that the --version parameter exists and that it has the specified
standard output format.

Closes #70

Signed-off-by: Konstantinos Papadopoulos <konpap1996@yahoo.com>