### PR TITLE
Fix codecov stats for main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: Tests and Lint
 on:
   workflow_dispatch:
   pull_request:
+  push:
+    branches:
+      - "main"
 
 jobs:
   build:


### PR DESCRIPTION
The tests must run in the push to main branch.
It will send to codecov the current stats to the main branch.

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>