### PR TITLE
Add "requirements" in the tox.in envlist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = py39,py310,lint,test
+envlist = py39,py310,lint,requirements,test
 skipsdist = true
 
 


### PR DESCRIPTION
Fixes: #86

Add "requirements" in the tox.in envlist.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>