### PR TITLE
Pin hashes for GitHub actions in workflow ci file

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,12 +18,12 @@ jobs:
       release_id: ${{ steps.gh-release.outputs.id }}
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@v3
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984
         with:
           python-version: '3.x'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
         python-versions: [ "3.9", "3.10", ]
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+    - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984
       with:
         python-version: ${{ matrix.python-versions }}
 
@@ -33,7 +33,7 @@ jobs:
       run: make tests
 
     - name: Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
       with:
         files: coverage.xml
         fail_ci_if_error: false


### PR DESCRIPTION
Pin hashes for GitHub actions in workflow yml files.
This will allow dependabot to update our actions by using hashes
as well.

I checked the latest stable versions for each of our action dependencies and got the commit hashes.
I have done a check for security advisories for each of the actions, but haven't found any.

The versions I have used for each of the actions are as follows:
- [actions/checkout v3.1.0](https://github.com/actions/checkout/releases/tag/v3.1.0)
- [actions/setup-python v4.3.0](https://github.com/actions/setup-python/releases/tag/v4.3.0)
- [codecov/codecov-action v3.1.1](https://github.com/codecov/codecov-action/releases/tag/v3.1.1)

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>