### PR TITLE
build: add workflow for updating python dependencies

### DIFF
--- a/.github/workflows/update-python-deps.yml
+++ b/.github/workflows/update-python-deps.yml
@@ -1,0 +1,35 @@
+name: Update Python dependencies
+ on:
+   workflow_dispatch:
+   schedule:
+     - cron: "0 8 * * *"
+ jobs:
+   update-dep:
+     runs-on: ubuntu-latest
+     strategy:
+       matrix:
+         python-versions: ["3.10"]
+     steps:
+       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984
+         with:
+           python-version: ${{ matrix.python-versions }}
+       - name: Install prerequisites
+         run: |
+           pip install tox pipenv
+       - name: Update dependencies
+         run: |
+           pipenv update -d
+           make requirements
+       - name: Run tests
+         run: |
+           make tests
+       - name: Create Pull Request
+         uses: peter-evans/create-pull-request@b4d51739f96fca8047ad065eccef63442d8e99f7
+         with:
+           token: ${{ secrets.GITHUB_TOKEN }}
+           commit-message: "build: Update Python dependencies"
+           title: "build: Update Python dependencies"
+           body: >
+             The following PR updates the Python dependencies and generates new pipfile and requirements file.
+           labels: report, automated pr, python

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = py39,py310,lint,requirements,test
+envlist = py310,lint,requirements,test
 skipsdist = true
 
 
@@ -45,5 +45,4 @@ commands =
 
 [gh-actions]
 python =
-    3.9: py39,pep8,lint,requirements,test,docs
     3.10: py310,pep8,lint,requirements,test,docs


### PR DESCRIPTION
The following PR adds a dedicated workflow for updating Python dependencies.

Details:
* Runs daily
* If another one is already opened, it doesn't create a new one, instead, it updates it.

Related to https://github.com/vmware/repository-service-tuf/issues/84

Signed-off-by: Radoslav Dimitrov <dimitrovr@vmware.com>