### PR TITLE
Simplify _key_is_duplicated() argument

### DIFF
--- a/repository_service_tuf/cli/admin/ceremony.py
+++ b/repository_service_tuf/cli/admin/ceremony.py
@@ -8,7 +8,6 @@
 import json
 import os
 import time
-from collections.abc import ValuesView
 from dataclasses import asdict, dataclass
 from enum import Enum
 from typing import Any, Dict
@@ -288,11 +287,11 @@ SETTINGS = PayloadSettings(
 
 
 def _key_is_duplicated(
-    roles_keys_input_list: ValuesView[RoleSettingsInput],
+    roles_settings: list[RoleSettingsInput],
     key: KeySchema.key,
     filepath: str,
 ) -> bool:
-    for role in roles_keys_input_list:
+    for role in roles_settings:
         if any(k for k in role.keys.values() if key == k.key.key):
             return True
 
@@ -412,9 +411,9 @@ def _configure_keys(rolename: str, role: RoleSettingsInput) -> None:
             else:
                 raise click.ClickException("Required key not validated.")
 
+        roles_settings = list(SETTINGS.roles.values())
         if key.key is not None and (
-            _key_is_duplicated(SETTINGS.roles.values(), key.key, filepath)
-            is True
+            _key_is_duplicated(roles_settings, key.key, filepath) is True
         ):
             console.print(":cross_mark: [red]Failed[/]: Key is duplicated.")
             continue


### PR DESCRIPTION
The _key_is_duplicated() function now accepts the
"roles_keys_input_list: ValuesView[RoleSettingsInput]" argument which seems complicated.
Instead of using ValuesView as a type, we can instead use "list" as a type as the only place, where we use the "roles_keys_input_list", is as a list. Also, the name "roles_keys_input_list" suggests the type should be a list.

Additionally, try to give a better name than "roles_keys_input_list".

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>