### PR TITLE
Fix Dynaconf[ini] dependency in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
   "click",
-  "dynaconf",
+  "dynaconf[ini]",
   "PyNaCl",
   "requests",
   "rich",


### PR DESCRIPTION
In pyproject.toml we should depend on dynaconf[ini] instead of only dynaconf in order to install the 
"configobj" file together with dynaconf.

Close #119

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>