### PR TITLE
build: functional tests before release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,10 +10,17 @@ permissions:
   contents: write
 
 jobs:
+  functional-latest:
+    uses: vmware/repository-service-tuf/.github/workflows/functional.yml@main
+    with:
+      worker_version: latest
+      api_version: latest
+      cli_version: dev
 
   build:
     name: Build
     runs-on: ubuntu-latest
+    needs: functional-latest
     outputs:
       release_id: ${{ steps.gh-release.outputs.id }}
     steps:


### PR DESCRIPTION
When a release is trigged, it uses the functional tests from vmware/repository-service-tuf (umbrella repository).

The release is build/published if the functional tests is ok

Closes #116

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>