### PR TITLE
Revert "Dev/add UT for ceremony._key_is_duplicated (#88)"

### DIFF
--- a/repository_service_tuf/helpers/tuf.py
+++ b/repository_service_tuf/helpers/tuf.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -33,28 +33,11 @@ repository_metadata: Dict[str, Metadata] = {}
 
 
 @dataclass
-class KeySchema:
-    # "key": Any (Any follows the ED25519KEY_SCHEMA from securesystemslib)
-    key: Optional[Dict[str, Any]] = None
-    error: Optional[str] = None
-
-
-@dataclass
-class KeyInput:
-    filepath: str
-    password: str
-    key: KeySchema
-
-    def to_dict(self):
-        return asdict(self)
-
-
-@dataclass
-class RoleSettingsInput:
+class RolesKeysInput:
     expiration: int = 1
     num_of_keys: int = 1
     threshold: int = 1
-    keys: Dict[str, KeyInput] = None
+    keys: Dict[str, Any] = field(default_factory=dict)
     offline_keys: bool = True
     paths: Optional[List[str]] = None
     number_hash_prefixes: Optional[int] = None
@@ -64,7 +47,7 @@ class RoleSettingsInput:
 
 
 def initialize_metadata(
-    settings: Dict[str, RoleSettingsInput], save=True
+    settings: Dict[str, RolesKeysInput], save=True
 ) -> Dict[str, Metadata]:
     """
     Creates development TUF top-level role metadata (root, targets, snapshot,
@@ -99,8 +82,8 @@ def initialize_metadata(
     def _signers(role_name: str) -> List[Signer]:
         """Returns all Signers from the settings for a specific role name"""
         return [
-            SSlibSigner(key_input.key.key)
-            for key_input in settings[role_name].keys.values()
+            SSlibSigner(key["key"])
+            for key in settings[role_name].keys.values()
         ]
 
     def _sign(role: Metadata, role_name: str) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import os
-from dataclasses import dataclass
 from tempfile import TemporaryDirectory
-from typing import Any, Dict, Optional
 
 import pytest  # type: ignore
 from click.testing import CliRunner  # type: ignore
@@ -23,13 +21,3 @@ def test_context():
 def client():
     runner = CliRunner()
     return runner
-
-
-@pytest.fixture
-def fake_key():
-    @dataclass
-    class FakeKey:
-        key: Optional[Dict[str, Any]] = None
-        error: Optional[str] = None
-
-    return FakeKey


### PR DESCRIPTION
The following PR reverts commit b2afa4688fb646dbbd56f8e98767cbc70ca7a092, because it introduces an incompatible payload with `rstuf-api`.

**Reproduce:**
* Deploy rstuf
* Use the latest CLI
* Perform the ceremony online OR generate a payload with the CLI offline and upload it

**Impacts:**
* repository-service-tuf-cli >= [v0.0.1a4](https://github.com/vmware/repository-service-tuf-cli/releases/tag/v0.0.1a4) 

**Reference:** 
```
Configuration correct for bins? [y/n]: y
╭─ Error ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Error 422 [{'loc': ['body', 'settings', 'roles', 'snapshot', 'keys', 'snapshot_1', 'filename'], 'msg': 'field required', 'type': 'value_error.missing'}, {'loc': ['body', 'settings', 'roles', 'snapshot', 'keys', 'snapshot_1', 'key', 'keytype'], 'msg': 'field required', 'type': 'value_error.missing'}, {'loc': ['body', 'settings', 'roles', 'snapshot', 'keys', 'snapshot_1', 'key', 'scheme'], 'msg': 'field required', 'type': 'value_error.missing'}, {'loc':         │
│ ['body', 'settings', 'roles', 'snapshot', 'keys', 'snapshot_1', 'key', 'keyid'], 'msg': 'field required', 'type': 'value_error.missing'}, {'loc': ['body', 'settings', 'roles', 'snapshot', 'keys', 'snapshot_1', 'key', 'keyid_hash_algorithms'], 'msg': 'field required', 'type': 'value_error.missing'}, {'loc': ['body', 'settings', 'roles', 'snapshot', 'keys', 'snapshot_1', 'key', 'keyval'], 'msg': 'field required', 'type': 'value_error.missing'}, {'loc': ['body', │
│ 'settings', 'roles', 'timestamp', 'keys', 'timestamp_1', 'filename'], 'msg': 'field required', 'type': 'value_error.missing'}, {'loc': ['body', 'settings', 'roles', 'timestamp', 'keys', 'timestamp_1', 'key', 'keytype'], 'msg': 'field required', 'type': 'value_error.missing'}, {'loc': ['body', 'settings', 'roles', 'timestamp', 'keys', 'timestamp_1', 'key', 'scheme'], 'msg': 'field required', 'type': 'value_error.missing'}, {'loc': ['body', 'settings', 'roles', │
│ 'timestamp', 'keys', 'timestamp_1', 'key', 'keyid'], 'msg': 'field required', 'type': 'value_error.missing'}, {'loc': ['body', 'settings', 'roles', 'timestamp', 'keys', 'timestamp_1', 'key', 'keyid_hash_algorithms'], 'msg': 'field required', 'type': 'value_error.missing'}, {'loc': ['body', 'settings', 'roles', 'timestamp', 'keys', 'timestamp_1', 'key', 'keyval'], 'msg': 'field required', 'type': 'value_error.missing'}, {'loc': ['body', 'settings', 'roles',    │
│ 'bins', 'keys', 'bins_1', 'filename'], 'msg': 'field required', 'type': 'value_error.missing'}, {'loc': ['body', 'settings', 'roles', 'bins', 'keys', 'bins_1', 'key', 'keytype'], 'msg': 'field required', 'type': 'value_error.missing'}, {'loc': ['body', 'settings', 'roles', 'bins', 'keys', 'bins_1', 'key', 'scheme'], 'msg': 'field required', 'type': 'value_error.missing'}, {'loc': ['body', 'settings', 'roles', 'bins', 'keys', 'bins_1', 'key', 'keyid'], 'msg':  │
│ 'field required', 'type': 'value_error.missing'}, {'loc': ['body', 'settings', 'roles', 'bins', 'keys', 'bins_1', 'key', 'keyid_hash_algorithms'], 'msg': 'field required', 'type': 'value_error.missing'}, {'loc': ['body', 'settings', 'roles', 'bins', 'keys', 'bins_1', 'key', 'keyval'], 'msg': 'field required', 'type': 'value_error.missing'}]                                                                                                                          │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

Closes #132 

(edited)