### PR TITLE
Run isort with the pre-commit tool

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
   rev: '5.10.1'
   hooks:
   - id: isort
-    args: [-l79, --profile, black, --check, --diff, .]
+    args: [-l79, --profile, black, --check, --diff]
 - repo: https://github.com/psf/black
   rev: '22.10.0'
   hooks:


### PR DESCRIPTION
In the .pre-commit-config.yaml file when we call isort we pass the current directory as a location where isort should lint. This in turn overrides all excludes made by the pre-commit tool as after that, we call isort upon all folders.

For example, I have a local virtual environment with the name ".env" and even if I add the "exclude" option for isort it doesn't work. Now, when we don't provide the target folders to isort the pre-commit tool does that and successfully ignores the ".env" folder.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>