### PR TITLE
Refactor contribution content in README and CONTRIBUTING files

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -5,7 +5,8 @@ Contributing to Repository Service for TUF CLI
 We welcome contributions from the community and first want to thank you for
 taking the time to contribute!
 
-Please familiarize yourself with the `Code of Conduct`_
+Please familiarize yourself with the `Code of Conduct
+<https://repository-service-tuf.readthedocs.io/en/latest/devel/contributing.html#id1>`_
 before contributing.
 
 DCO
@@ -36,5 +37,128 @@ Pull Request. Contributions may include:
 * Helping to onboard new contributors
 * Other related activities
 
+Development
+===========
 
-Check `README.rst <README.rst>`_ development section instructions.
+Requirements
+-------------
+
+- Python >=3.9
+- Pipenv
+
+Getting the source code
+-----------------------
+
+`Fork <https://docs.github.com/en/get-started/quickstart/fork-a-repo>`_ the
+repository on `GitHub <https://github.com/vmware/repository-service-tuf-cli>`_ and
+`clone <https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository>`_
+it to your local machine:
+
+.. code-block:: console
+
+    git clone git@github.com:YOUR-USERNAME/repository-service-tuf-cli.git
+
+Add a `remote
+<https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/configuring-a-remote-for-a-fork>`_ and
+regularly `sync <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork>`_ to make sure
+you stay up-to-date with our repository:
+
+.. code-block:: console
+
+    git remote add upstream https://github.com/vmware/repository-service-tuf-cli
+    git checkout main
+    git fetch upstream
+    git merge upstream/main
+
+Preparing the environment
+-------------------------
+
+After installing Python, install the pipenv tool:
+
+.. code:: shell
+
+    $ pip install pipenv
+
+
+Create a virtual environment for this project:
+
+.. code:: shell
+
+    $ pipenv shell
+
+
+Install the requirements from the Pipfile.
+
+The flag -d will install the development requirements:
+
+.. code:: shell
+
+    $ pipenv install -d
+
+
+.. note::
+
+    macOS running on MacBook M1
+
+    For developers, after the above command, run:
+
+    .. code:: shell
+
+        $ pip uninstall cryptography cffi -y
+        $ pip cache purge
+        $ LDFLAGS=-L$(brew --prefix libffi)/lib CFLAGS=-I$(brew --prefix libffi)/include pip install cffi cryptography
+
+
+Running checks with pre-commit:
+
+The pre-commit tool is installed as part of the development requirements.
+
+To automatically run checks before you commit your changes you should run:
+
+.. code:: shell
+
+    $ make precommit
+
+This will install the git hook scripts for the first time, it will update to the
+latest versions of the hooks and run the pre-commit tool.
+Now ``pre-commit`` will run automatically on ``git commit``.
+
+
+Running RSTUF CLI:
+
+.. code:: shell
+
+    $ rstuf
+
+    Usage: rstuf [OPTIONS] COMMAND [ARGS]...
+
+    Repository Service for TUF Command Line Interface (CLI).
+
+How to add new requirements
+---------------------------
+
+Install the requirements package.
+
+The flag -d will install the development requirements.
+
+.. code:: shell
+
+    $ pipenv install -d <package>
+    $ pipenv install <package>
+
+
+Update all project requirements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code:: shell
+
+    $ make requirements
+
+Tests
+-----
+
+Perform automated testing with the tox tool:
+
+.. code:: shell
+
+    $ tox

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -109,8 +109,8 @@ The flag -d will install the development requirements:
         $ LDFLAGS=-L$(brew --prefix libffi)/lib CFLAGS=-I$(brew --prefix libffi)/include pip install cffi cryptography
 
 
-Running checks with pre-commit:
-
+Running checks with pre-commit
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The pre-commit tool is installed as part of the development requirements.
 
 To automatically run checks before you commit your changes you should run:
@@ -119,12 +119,13 @@ To automatically run checks before you commit your changes you should run:
 
     $ make precommit
 
-This will install the git hook scripts for the first time, it will update to the
+This will install the git hook scripts for the first time, update to the
 latest versions of the hooks and run the pre-commit tool.
 Now ``pre-commit`` will run automatically on ``git commit``.
 
 
-Running RSTUF CLI:
+Running RSTUF CLI
+~~~~~~~~~~~~~~~~~
 
 .. code:: shell
 
@@ -148,7 +149,7 @@ The flag -d will install the development requirements.
 
 
 Update all project requirements
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code:: shell
 

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ The Repository Service for TUF Command Line Interface (CLI) is a CLI Python
 application to manage the Repository Service for TUF.
 
 The CLI supports the initial setup, termed a ceremony, where the first repository
-metadata are signed and the service is configured, generating Tokens to be used
+metadata are signed and the service is configured, generating tokens to be used
 by integration (i.e., CI/CD tools).
 
 This CLI is part of the Repository Service for TUF (RSTUF).

--- a/README.rst
+++ b/README.rst
@@ -42,9 +42,9 @@ Contributing
 Please, visit the `Repository Service for TUF Development Guide
 <https://repository-service-tuf.readthedocs.io/en/latest/devel/index.html#development-guide>`_.
 
-Check our `CONTRIBUTING.rst <CONTRIBUTING.rst>`_ for more details on how to
-contribute to this repository.
+Check our `CONTRIBUTING.rst <https://github.com/vmware/repository-service-tuf-cli/blob/main/CONTRIBUTING.rst>`_
+for more details on how to contribute to this repository.
 
 License
 =======
-`MIT <LICENSE>`_
+`MIT <https://github.com/vmware/repository-service-tuf-cli/blob/main/LICENSE>`_

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,12 @@ Repository Service for TUF Command Line Interface
 .. |Coverage| image:: https://codecov.io/gh/vmware/repository-service-tuf-cli/branch/main/graph/badge.svg
   :target: https://codecov.io/gh/vmware/repository-service-tuf-cli
 
-Repository Service for TUF Command Line Interface (CLI).
+The Repository Service for TUF Command Line Interface (CLI) is a CLI Python
+application to manage the Repository Service for TUF.
+
+The CLI supports the initial setup, termed a ceremony, where the first repository
+metadata are signed and the service is configured, generating Tokens to be used
+by integration (i.e., CI/CD tools).
 
 This CLI is part of the Repository Service for TUF (RSTUF).
 
@@ -17,132 +22,29 @@ This CLI is part of the Repository Service for TUF (RSTUF).
 
     Not a functional tool, it is still in the development stage. Wait for release 0.0.1
 
-Development
-###########
-
-Requirements:
-=============
-
-- Python >=3.9
-- Pipenv
-
-Getting the source code
-=======================
-
-`Fork <https://docs.github.com/en/get-started/quickstart/fork-a-repo>`_ the
-repository on `GitHub <https://github.com/vmware/repository-service-tuf-cli>`_ and
-`clone <https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository>`_
-it to your local machine:
-
-.. code-block:: console
-
-    git clone git@github.com:YOUR-USERNAME/repository-service-tuf-cli.git
-
-Add a `remote
-<https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/configuring-a-remote-for-a-fork>`_ and
-regularly `sync <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork>`_ to make sure
-you stay up-to-date with our repository:
-
-.. code-block:: console
-
-    git remote add upstream https://github.com/vmware/repository-service-tuf-cli
-    git checkout main
-    git fetch upstream
-    git merge upstream/main
-
-
-Preparing the environment
-=========================
-
-After installing Python, install the pipenv tool:
+Installation
+============
+Using pip:
 
 .. code:: shell
 
-    $ pip install pipenv
+    $ pip install repository-service-tuf
 
-
-Create a virtual environment for this project:
-
-.. code:: shell
-
-    $ pipenv shell
-
-
-Install the requirements from the Pipfile.
-
-The flag -d will install the development requirements:
-
-.. code:: shell
-
-    $ pipenv install -d
-
-
-.. note::
-
-    macOS running on MacBook M1
-
-    For developers, after the above command, run:
-
-    .. code:: shell
-
-        $ pip uninstall cryptography cffi -y
-        $ pip cache purge
-        $ LDFLAGS=-L$(brew --prefix libffi)/lib CFLAGS=-I$(brew --prefix libffi)/include pip install cffi cryptography
-
-
-Running checks with pre-commit:
-
-The pre-commit tool is installed as part of the development requirements.
-
-To automatically run checks before you commit your changes you should run:
-
-.. code:: shell
-
-    $ make precommit
-
-This will install the git hook scripts for the first time, it will update to the
-latest versions of the hooks and run the pre-commit tool.
-Now ``pre-commit`` will run automatically on ``git commit``.
-
-
-Running RSTUF CLI:
-
-.. code:: shell
-
-    $ rstuf
-
-    Usage: rstuf [OPTIONS] COMMAND [ARGS]...
-
-    Repository Service for TUF Command Line Interface (CLI).
-
-
-
-How to add new requirements
-===========================
-
-Install the requirements package.
-
-The flag -d will install the development requirements.
-
-.. code:: shell
-
-    $ pipenv install -d <package>
-    $ pipenv install <package>
-
-
-Update all project requirements
--------------------------------
-
-.. code:: shell
-
-    $ make requirements
-
-Tests
+Usage
 =====
+Please, check the `Repository Service for TUF Guide
+<https://repository-service-tuf.readthedocs.io/en/latest/guide/repository-service-tuf-cli/index.html>`_
+for more details.
 
-Perform automated testing with the tox tool:
+Contributing
+============
 
-.. code:: shell
+Please, visit the `Repository Service for TUF Development Guide
+<https://repository-service-tuf.readthedocs.io/en/latest/devel/index.html#development-guide>`_.
 
-    $ tox
+Check our `CONTRIBUTING.rst <CONTRIBUTING.rst>`_ for more details on how to
+contribute to this repository.
 
+License
+=======
+`MIT <LICENSE>`_


### PR DESCRIPTION
In general, in this PR we want to focus on the
restructuring of the README and CONTRIBUTING
files and not as much on their content.
This structure can be used similarly for the
other RSTUF projects.
This is an initial structure that will evolve and of
course it's just a suggestion to get started with,
please leave your feedback.

Implementation details:
- Moved the Development section of the README.rst to the CONTRIBUTING.rst as a new section and
adjusted it
- Added short Installation, Usage and License sections to the README.rst
- Fixed minor typos and made small improvements

Closes #124