### PR TITLE
Remove `read:targets` from the default admin login

### DIFF
--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -400,7 +400,7 @@ Generate tokens to use in integrations.
     ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
     │     --expires  -e  INTEGER  Expires in hours. Default: 24 [default: 24]                          │
     │  *  --scope    -s  TEXT     Scope to grant. Multiple is accepted. Ex: -s write:targets -s        │
-    │                             read:targets                                                         │
+    │                             read:settings                                                         │
     │                             [required]                                                           │
     │     --help     -h           Show this message and exit.                                          │
     ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯

--- a/repository_service_tuf/cli/admin/login.py
+++ b/repository_service_tuf/cli/admin/login.py
@@ -83,7 +83,6 @@ def _run_login(context, server_, user_, password_, expires_):
         "password": password,
         "scope": (
             "write:targets "
-            "read:targets "
             "write:bootstrap "
             "read:bootstrap "
             "read:settings "

--- a/repository_service_tuf/cli/admin/token.py
+++ b/repository_service_tuf/cli/admin/token.py
@@ -40,7 +40,7 @@ def token(context):
     "scope",
     help=(
         "Scope to grant. Multiple is accepted. Ex: -s write:targets"
-        " -s read:targets"
+        " -s read:settings"
     ),
     multiple=True,
     required=True,


### PR DESCRIPTION
Removes `read:targets` from the default admin login scopes.

The `read:targets` scope was removed from the RSTUF API
- https://github.com/vmware/repository-service-tuf-api/pull/180

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>