### PR TITLE
tests: save metadata when generate the default

### DIFF
--- a/repository_service_tuf/cli/admin/ceremony.py
+++ b/repository_service_tuf/cli/admin/ceremony.py
@@ -576,8 +576,8 @@ def _bootstrap_state(task_id, server, headers):
     "-s",
     "--save",
     help=(
-        "Save a copy of the metadata localy. This option saves the metadata "
-        "files (json) in the 'metadata' dir."
+        "Save a copy of the metadata locally. This option saves the metadata "
+        "files (json) in the 'metadata' folder in the current directory."
     ),
     show_default=True,
     is_flag=True,

--- a/tests/unit/cli/admin/test_ceremony.py
+++ b/tests/unit/cli/admin/test_ceremony.py
@@ -357,6 +357,7 @@ class TestCeremonyGroupCLI:
 
         test_result = client.invoke(
             ceremony.ceremony,
+            ["--save"],
             input="\n".join(input_step1 + input_step2),
             obj=test_context,
         )


### PR DESCRIPTION
This will save the metadata during the UT for bootstrap.

This data can be reused in other tests such as FT

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>