### PR TITLE
Remove python3.9 and add python3.11 ci build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-versions: [ "3.9", "3.10", ]
+        python-versions: [ "3.10", "3.11" ]
 
     steps:
     - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b


### PR DESCRIPTION
I noticed we run build for python3.9 when we say we support only python3.10 onwards.
That's why it seemed unnecessary that we are testing for python3.9.

On the other hand, python 3.11 was introduced back in October 2022 and we can directly add support for it.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>