### PR TITLE
Reintroduce mypy checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,5 +37,12 @@ repos:
       description: Checks if `make requirements` is up-to-date
       entry: tox -e requirements
       language: system
-      files: ''
+      pass_filenames: false
+      verbose: true
+    - id: tox-mypy
+      name: run typing check from tox
+      description: Checks typing with `mypy`
+      entry: tox -e typing
+      language: system
+      pass_filenames: false
       verbose: true

--- a/Pipfile
+++ b/Pipfile
@@ -37,6 +37,7 @@ hatchling = "==0.22.0"
 build = "*"
 pre-commit = "*"
 bandit = "*"
+types-requests = "*"
 
 [requires]
 python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3638f0878dec39c78deeca07b555bf8a96d790e23fdcf2ff8d7c79b2336163a7"
+            "sha256": "73a082dc6f92fb13af3e8f0357fb5f1577e8134e253ce914e420533e0c4e5e30"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -344,7 +344,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.16.0"
         },
         "tuf": {
@@ -641,7 +641,7 @@
                 "sha256:167524e377358ed1f1374e61c268f0d7a4bf7dbd046c656f7b410cde16161b1a",
                 "sha256:ee686a8db9f5d91da39849f175ffeef094dd0e9c36d6a59a2e8c7f92a3b80020"
             ],
-            "markers": "python_version >= '3.1'",
+            "markers": "python_version > '3'",
             "version": "==0.3"
         },
         "exceptiongroup": {
@@ -694,11 +694,11 @@
         },
         "identify": {
             "hashes": [
-                "sha256:832832a58ecc1b8f33d5e8cb4f7d3db2f5c7fbe922dfee5f958b48fed691501a",
-                "sha256:c47acedfe6495b1c603ed7e93469b26e839cab38db4155113f36f718f8b3dc47"
+                "sha256:7d526dd1283555aafcc91539acc061d8f6f59adb0a7bba462735b0a318bff7ed",
+                "sha256:93cc61a861052de9d4c541a7acb7e3dcc9c11b398a2144f6e52ae5285f5f4f06"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.5.16"
+            "version": "==2.5.17"
         },
         "idna": {
             "hashes": [
@@ -860,7 +860,7 @@
                 "sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2",
                 "sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"
             ],
-            "markers": "python_version >= '3.1'",
+            "markers": "python_version > '3'",
             "version": "==23.0"
         },
         "pathspec": {
@@ -900,7 +900,7 @@
                 "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
                 "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
             ],
-            "markers": "python_version >= '3.1'",
+            "markers": "python_version > '3'",
             "version": "==1.0.0"
         },
         "pre-commit": {
@@ -1127,7 +1127,7 @@
                 "sha256:7f8aeb6e3f90f96832c301bff21a7eb5eefbe894c88c506483d355565d88cc1a",
                 "sha256:aa6436565c069b2946fe4ebff07f5041e0c8bf18c7376dd29edf80cf7d524e4e"
             ],
-            "markers": "python_version >= '3.8'",
+            "markers": "python_full_version >= '3.8.0'",
             "version": "==4.1.1"
         },
         "tomli": {
@@ -1135,7 +1135,7 @@
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
                 "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_version >= '3.1'",
+            "markers": "python_version > '3'",
             "version": "==2.0.1"
         },
         "tox": {
@@ -1145,6 +1145,21 @@
             ],
             "index": "pypi",
             "version": "==4.4.2"
+        },
+        "types-requests": {
+            "hashes": [
+                "sha256:61960554baca0008ae7e2db2bd3b322ca9a144d3e80ce270f5fb640817e40994",
+                "sha256:e67424525f84adfbeab7268a159d3c633862dafae15c5b19547ce1b55954f0a3"
+            ],
+            "index": "pypi",
+            "version": "==2.28.11.8"
+        },
+        "types-urllib3": {
+            "hashes": [
+                "sha256:ed6b9e8a8be488796f72306889a06a3fc3cb1aa99af02ab8afb50144d7317e49",
+                "sha256:eec5556428eec862b1ac578fb69aab3877995a99ffec9e5a12cf7fbd0cc9daee"
+            ],
+            "version": "==1.26.25.4"
         },
         "typing-extensions": {
             "hashes": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,13 @@ dependencies = [
 ]
 dynamic = ["version"]
 
+[tool.mypy]
+exclude = "docs/"
+
+[[tool.mypy.overrides]]
+module = ["dynaconf", "pretend"]
+ignore_missing_imports = true
+
 [tool.hatch.version]
 path = "repository_service_tuf/__version__.py"
 

--- a/repository_service_tuf/cli/admin/ceremony.py
+++ b/repository_service_tuf/cli/admin/ceremony.py
@@ -695,7 +695,7 @@ def ceremony(context, bootstrap, file, upload, save) -> None:
                 )
 
                 if rolename == Roles.TARGETS.value:
-                    assert role.paths is not None
+                    assert role.paths is not None  # nosec B101:assert_used
                     delegations_row = (
                         f"\n{SETTINGS.service.targets_base_url}".join(
                             ["", *role.paths]

--- a/repository_service_tuf/helpers/tuf.py
+++ b/repository_service_tuf/helpers/tuf.py
@@ -217,7 +217,7 @@ def initialize_metadata(
         )
     }
 
-    assert targets_metadata_roles is not None
+    assert targets_metadata_roles is not None  # nosec B101:assert_used
 
     targets_metadata.signed.delegations.roles = targets_metadata_roles
 
@@ -235,7 +235,7 @@ def initialize_metadata(
     targets_meta.append((Targets.type, targets_metadata.signed.version))
 
     bit_length = settings[BINS].number_hash_prefixes
-    assert bit_length is not None
+    assert bit_length is not None  # nosec B101:assert_used
 
     succinct_roles = SuccinctRoles([], 1, bit_length, BINS)
     # Create new 'bins' role and delegate trust from 'bins' for all target

--- a/repository_service_tuf/helpers/tuf.py
+++ b/repository_service_tuf/helpers/tuf.py
@@ -185,7 +185,7 @@ def initialize_metadata(
 
         # Bootstrap default top-level metadata to be updated below if necessary
         if role is Root:
-            metadata = Metadata(role(roles=roles))
+            metadata = Metadata(Root(roles=roles))
             root = metadata.signed
             for arg in add_key_args:
                 root.add_key(arg[0], arg[1])
@@ -216,8 +216,6 @@ def initialize_metadata(
             paths=settings[Targets.type].paths,
         )
     }
-
-    assert targets_metadata_roles is not None  # nosec B101:assert_used
 
     targets_metadata.signed.delegations.roles = targets_metadata_roles
 

--- a/repository_service_tuf/helpers/tuf.py
+++ b/repository_service_tuf/helpers/tuf.py
@@ -163,7 +163,7 @@ def initialize_metadata(
 
     # Populate public key store, and define trusted signing keys and required
     # signature thresholds for each top-level role in 'root'.
-    roles = {}
+    roles: dict[str, Role] = {}
     for role_name in TOP_LEVEL_ROLE_NAMES:
         threshold = settings[role_name].threshold
         signers = _signers(role_name)
@@ -180,14 +180,14 @@ def initialize_metadata(
             )
 
         roles[role_name] = Role([], threshold)
-        keys: list[tuple[Key, str]] = [
+        add_key_args: list[tuple[Key, str]] = [
             (Key.from_securesystemslib_key(signer.key_dict), role_name)
             for signer in signers
         ]
 
     root = Root(roles=roles)
-    for key in keys:
-        root.add_key(key[0], key[1])
+    for arg in add_key_args:
+        root.add_key(arg[0], arg[1])
 
     # Add signature wrapper, bump expiration, and sign and persist
     for role in [targets, snapshot, timestamp, root]:
@@ -207,7 +207,7 @@ def initialize_metadata(
     # required signature thresholds.
     targets_metadata = _load(Targets.type)
     targets_metadata.signed.delegations = Delegations(keys={}, roles={})
-    targets_metadata_roles = {
+    targets_metadata_roles: dict[str, DelegatedRole] = {
         BIN: DelegatedRole(
             name=BIN,
             keyids=[],

--- a/repository_service_tuf/helpers/tuf.py
+++ b/repository_service_tuf/helpers/tuf.py
@@ -159,6 +159,7 @@ def initialize_metadata(
     # Populate public key store, and define trusted signing keys and required
     # signature thresholds for each top-level role in 'root'.
     roles: dict[str, Role] = {}
+    add_key_args: list[tuple[Key, str]] = []
     for role_name in TOP_LEVEL_ROLE_NAMES:
         threshold = settings[role_name].threshold
         signers = _signers(role_name)
@@ -175,10 +176,10 @@ def initialize_metadata(
             )
 
         roles[role_name] = Role([], threshold)
-        add_key_args: list[tuple[Key, str]] = [
-            (Key.from_securesystemslib_key(signer.key_dict), role_name)
-            for signer in signers
-        ]
+        for signer in signers:
+            add_key_args.append(
+                (Key.from_securesystemslib_key(signer.key_dict), role_name)
+            )
 
     # Add signature wrapper, bump expiration, and sign and persist
     for role in [Targets, Snapshot, Timestamp, Root]:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,57 +1,57 @@
 -i https://pypi.org/simple
-alabaster==0.7.13 ; python_version >= '3.6'
-attrs==22.2.0 ; python_version >= '3.6'
-babel==2.11.0 ; python_version >= '3.6'
+alabaster==0.7.13; python_version >= '3.6'
+attrs==22.2.0; python_version >= '3.6'
+babel==2.11.0; python_version >= '3.6'
 bandit==1.7.4
 black==22.12.0
 build==0.10.0
-cachetools==5.3.0 ; python_version ~= '3.7'
-certifi==2022.12.7 ; python_version >= '3.6'
-cfgv==3.3.1 ; python_full_version >= '3.6.1'
-chardet==5.1.0 ; python_version >= '3.7'
+cachetools==5.3.0; python_version ~= '3.7'
+certifi==2022.12.7; python_version >= '3.6'
+cfgv==3.3.1; python_full_version >= '3.6.1'
+chardet==5.1.0; python_version >= '3.7'
 charset-normalizer==3.0.1
 click==8.1.3
-colorama==0.4.6 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
+colorama==0.4.6; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
 coverage==7.1.0
 distlib==0.3.6
-docutils==0.19 ; python_version >= '3.7'
-editables==0.3 ; python_version >= '3.1'
-exceptiongroup==1.1.0 ; python_version < '3.11'
-filelock==3.9.0 ; python_version >= '3.7'
+docutils==0.19; python_version >= '3.7'
+editables==0.3; python_version > '3'
+exceptiongroup==1.1.0; python_version < '3.11'
+filelock==3.9.0; python_version >= '3.7'
 flake8==6.0.0
-gitdb==4.0.10 ; python_version >= '3.7'
-gitpython==3.1.30 ; python_version >= '3.7'
+gitdb==4.0.10; python_version >= '3.7'
+gitpython==3.1.30; python_version >= '3.7'
 hatchling==0.22.0
-identify==2.5.16 ; python_version >= '3.7'
-idna==3.4 ; python_version >= '3.5'
-imagesize==1.4.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-iniconfig==2.0.0 ; python_version >= '3.7'
+identify==2.5.17; python_version >= '3.7'
+idna==3.4; python_version >= '3.5'
+imagesize==1.4.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+iniconfig==2.0.0; python_version >= '3.7'
 isort==5.12.0
-jinja2==3.1.2 ; python_version >= '3.7'
-markupsafe==2.1.2 ; python_version >= '3.7'
-mccabe==0.7.0 ; python_version >= '3.6'
+jinja2==3.1.2; python_version >= '3.7'
+markupsafe==2.1.2; python_version >= '3.7'
+mccabe==0.7.0; python_version >= '3.6'
 mypy==0.991
 mypy-extensions==0.4.3
-nodeenv==1.7.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
-packaging==23.0 ; python_version >= '3.1'
-pathspec==0.11.0 ; python_version >= '3.7'
-pbr==5.11.1 ; python_version >= '2.6'
+nodeenv==1.7.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
+packaging==23.0; python_version > '3'
+pathspec==0.11.0; python_version >= '3.7'
+pbr==5.11.1; python_version >= '2.6'
 pip==22.3.1
-platformdirs==2.6.2 ; python_version >= '3.7'
-pluggy==1.0.0 ; python_version >= '3.1'
+platformdirs==2.6.2; python_version >= '3.7'
+pluggy==1.0.0; python_version > '3'
 pre-commit==3.0.2
 pretend==1.0.9
-pycodestyle==2.10.0 ; python_version >= '3.6'
-pyflakes==3.0.1 ; python_version >= '3.6'
-pygments==2.14.0 ; python_version >= '3.6'
-pyproject-api==1.5.0 ; python_version >= '3.7'
-pyproject-hooks==1.0.0 ; python_version >= '3.7'
+pycodestyle==2.10.0; python_version >= '3.6'
+pyflakes==3.0.1; python_version >= '3.6'
+pygments==2.14.0; python_version >= '3.6'
+pyproject-api==1.5.0; python_version >= '3.7'
+pyproject-hooks==1.0.0; python_version >= '3.7'
 pytest==7.2.1
 pytz==2022.7.1
-pyyaml==6.0 ; python_version >= '3.6'
+pyyaml==6.0; python_version >= '3.6'
 requests==2.28.2
-setuptools==67.0.0 ; python_version >= '3.7'
-smmap==5.0.0 ; python_version >= '3.6'
+setuptools==67.0.0; python_version >= '3.7'
+smmap==5.0.0; python_version >= '3.6'
 snowballstemmer==2.2.0
 sphinx==6.1.3
 sphinx-rtd-theme==0.5.1
@@ -62,22 +62,24 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-plantuml==0.24.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
-stevedore==4.1.1 ; python_version >= '3.8'
-tomli==2.0.1 ; python_version >= '3.1'
+stevedore==4.1.1; python_full_version >= '3.8.0'
+tomli==2.0.1; python_version > '3'
 tox==4.4.2
-typing-extensions==4.4.0 ; python_version >= '3.7'
-urllib3==1.26.14 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
-virtualenv==20.17.1 ; python_version >= '3.6'
+types-requests==2.28.11.8
+types-urllib3==1.26.25.4
+typing-extensions==4.4.0; python_version >= '3.7'
+urllib3==1.26.14; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
+virtualenv==20.17.1; python_version >= '3.6'
 cffi==1.15.1
 configobj==5.0.8
 cryptography==39.0.0
 dynaconf[ini]==3.1.11
-markdown-it-py==2.1.0 ; python_version >= '3.7'
-mdurl==0.1.2 ; python_version >= '3.7'
+markdown-it-py==2.1.0; python_version >= '3.7'
+mdurl==0.1.2; python_version >= '3.7'
 pycparser==2.21
 pynacl==1.5.0
 rich==13.3.1
 rich-click==1.6.1
 securesystemslib[crypto]==0.26.0
-six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
 tuf==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,22 +1,22 @@
 -i https://pypi.org/simple
-certifi==2022.12.7 ; python_version >= '3.6'
+certifi==2022.12.7; python_version >= '3.6'
 cffi==1.15.1
 charset-normalizer==3.0.1
 click==8.1.3
 configobj==5.0.8
 cryptography==39.0.0
 dynaconf[ini]==3.1.11
-idna==3.4 ; python_version >= '3.5'
+idna==3.4; python_version >= '3.5'
 isort==5.12.0
-markdown-it-py==2.1.0 ; python_version >= '3.7'
-mdurl==0.1.2 ; python_version >= '3.7'
+markdown-it-py==2.1.0; python_version >= '3.7'
+mdurl==0.1.2; python_version >= '3.7'
 pycparser==2.21
-pygments==2.14.0 ; python_version >= '3.6'
+pygments==2.14.0; python_version >= '3.6'
 pynacl==1.5.0
 requests==2.28.2
 rich==13.3.1
 rich-click==1.6.1
 securesystemslib[crypto]==0.26.0
-six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
 tuf==2.0.0
-urllib3==1.26.14 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
+urllib3==1.26.14; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = py310,py311,lint,requirements,test
+envlist = py310,py311,lint,typing,requirements,test
 skipsdist = true
 
 
@@ -18,7 +18,10 @@ commands =
     pre-commit run isort --all-files --show-diff-on-failure
     pre-commit run black --all-files --show-diff-on-failure
     pre-commit run bandit --all-files --show-diff-on-failure
-    # mypy . #issue33
+
+[testenv:typing]
+commands =
+    mypy .
 
 [testenv:test]
 allowlist_externals = coverage
@@ -47,5 +50,5 @@ commands =
 
 [gh-actions]
 python =
-    3.10: py310,pep8,lint,requirements,test,docs
-    3.11: py311,pep8,lint,requirements,test,docs
+    3.10: py310,pep8,lint,typing,requirements,test,docs
+    3.11: py311,pep8,lint,typing,requirements,test,docs


### PR DESCRIPTION
Adding a bit of context below since this PR addresses quite a few typing issues.

- In the `_update_snapshot` function we encounter the following typing error: `repository_service_tuf/helpers/tuf.py:195: error: Value of type variable "T" of "Metadata" cannot be "Signed"  [type-var]`. I have ignored it for now, if we can't find a solution in the scope of this PR I suggest opening a new issue to track it, so that we don't block the merging of this PR.

- For errors of the type:
`error: Skipping analyzing <module_name>: module is installed, but missing library stubs or py.typed marker  [import]`, there are basically 4 possible options, see https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-library-stubs-or-py-typed-marker:
1. _Upgrading the version of the library you’re using, in case a newer version has started to include type hints._ - This is not the case for these libraries
2. _Searching to see if there is a PEP 561 compliant stub package. corresponding to your third party library._ - There are none
3. _Writing your own stub files containing type hints for the library._ - This is a substantial extra effort and could be considered in a different PR
4. _Suppress the errors. All this will do is make mypy stop reporting an error on the line containing the import: the imported module will continue to be of type Any._ - Which has the inherited drawback of not actually using types in this case. In this PR we are going with this option

- Excluded type-checking for `docs` directory. Currently, there is only one Python file to be checked there, which is a configuration file, `conf.py`.

- When populating the public key store in `_update_snapshot` function we encounter the error: `repository_service_tuf/helpers/tuf.py: error: Unsupported target for indexed assignment ("Mapping[str, Role]") [index]`.
Here we were assigning a value, `root.roles[role_name] = Role([], threshold)`, but from the `tuf` package `Root.roles` is a `Mapping` which does not support that.
We solve this issue by creating first the `roles` dictionary and initiating the `Root` class with it.

- For `_update_snapshot`, we see the error: `Unsupported target for indexed assignment ("Optional[Dict[str, DelegatedRole]]")  [index]`.
We have to assert that the added dict is not `None`, since the `Delegations.roles` property value is `Optional` in the original `tuf` package.
We encounter similar errors caused by discrepancies in our code and the original package's types (not handling the case that a variable might be `None` since in the original package the variable type includes `Optional`).

Closes #33