### PR TITLE
Add `crypto` extra to the `securesystemslib` requirement

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 rich-click = "*"
-securesystemslib = "*"
+securesystemslib = {extras = ["crypto"], version = "*"}
 click = "*"
 rich = "*"
 PyNaCl = "==1.5.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "32811e8c3219cbca27999d3824892fdfbf5ac2c9de9d93ff3d7c0801cefc4801"
+            "sha256": "456475e724cae26ff549b8125553f181e05eab5a671546d909ab03c7367a55e5"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -184,7 +184,6 @@
                 "sha256:f9d0c5c045a3ca9bedfc35dca8526798eb91a07aa7a2c0fee134c6c6f321cbd7",
                 "sha256:ff6f3db31555657f3163b15a6b7c6938d08df7adbfc9dd13d9d19edad678f1e8"
             ],
-            "markers": "python_full_version >= '3.6.0'",
             "version": "==3.0.1"
         },
         "click": {
@@ -202,6 +201,34 @@
                 "sha256:d808d7e04e6f81fbb23d5ac2cd50e69ccbee58eaf9360eb89ede22d93216a314"
             ],
             "version": "==5.0.8"
+        },
+        "cryptography": {
+            "hashes": [
+                "sha256:1a6915075c6d3a5e1215eab5d99bcec0da26036ff2102a1038401d6ef5bef25b",
+                "sha256:1ee1fd0de9851ff32dbbb9362a4d833b579b4a6cc96883e8e6d2ff2a6bc7104f",
+                "sha256:407cec680e811b4fc829de966f88a7c62a596faa250fc1a4b520a0355b9bc190",
+                "sha256:50386acb40fbabbceeb2986332f0287f50f29ccf1497bae31cf5c3e7b4f4b34f",
+                "sha256:6f97109336df5c178ee7c9c711b264c502b905c2d2a29ace99ed761533a3460f",
+                "sha256:754978da4d0457e7ca176f58c57b1f9de6556591c19b25b8bcce3c77d314f5eb",
+                "sha256:76c24dd4fd196a80f9f2f5405a778a8ca132f16b10af113474005635fe7e066c",
+                "sha256:7dacfdeee048814563eaaec7c4743c8aea529fe3dd53127313a792f0dadc1773",
+                "sha256:80ee674c08aaef194bc4627b7f2956e5ba7ef29c3cc3ca488cf15854838a8f72",
+                "sha256:844ad4d7c3850081dffba91cdd91950038ee4ac525c575509a42d3fc806b83c8",
+                "sha256:875aea1039d78557c7c6b4db2fe0e9d2413439f4676310a5f269dd342ca7a717",
+                "sha256:887cbc1ea60786e534b00ba8b04d1095f4272d380ebd5f7a7eb4cc274710fad9",
+                "sha256:ad04f413436b0781f20c52a661660f1e23bcd89a0e9bb1d6d20822d048cf2856",
+                "sha256:bae6c7f4a36a25291b619ad064a30a07110a805d08dc89984f4f441f6c1f3f96",
+                "sha256:c52a1a6f81e738d07f43dab57831c29e57d21c81a942f4602fac7ee21b27f288",
+                "sha256:e0a05aee6a82d944f9b4edd6a001178787d1546ec7c6223ee9a848a7ade92e39",
+                "sha256:e324de6972b151f99dc078defe8fb1b0a82c6498e37bff335f5bc6b1e3ab5a1e",
+                "sha256:e5d71c5d5bd5b5c3eebcf7c5c2bb332d62ec68921a8c593bea8c394911a005ce",
+                "sha256:f3ed2d864a2fa1666e749fe52fb8e23d8e06b8012e8bd8147c73797c506e86f1",
+                "sha256:f671c1bb0d6088e94d61d80c606d65baacc0d374e67bf895148883461cd848de",
+                "sha256:f6c0db08d81ead9576c4d94bbb27aed8d7a430fa27890f39084c2d0e2ec6b0df",
+                "sha256:f964c7dcf7802d133e8dbd1565914fa0194f9d683d82411989889ecd701e8adf",
+                "sha256:fec8b932f51ae245121c4671b4bbc030880f363354b2f0e0bd1366017d891458"
+            ],
+            "version": "==39.0.0"
         },
         "dynaconf": {
             "extras": [
@@ -294,6 +321,9 @@
             "version": "==1.6.1"
         },
         "securesystemslib": {
+            "extras": [
+                "crypto"
+            ],
             "hashes": [
                 "sha256:41c7b25c52dc0bafe774413b5738bbf4431f094e72a091e83d9921901972ae4c",
                 "sha256:a8fa49831d6a7e48f81050984ddfac3713af0c326f558727113533edb5ca8eac"
@@ -306,7 +336,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.16.0"
         },
         "tuf": {
@@ -511,7 +541,6 @@
                 "sha256:f9d0c5c045a3ca9bedfc35dca8526798eb91a07aa7a2c0fee134c6c6f321cbd7",
                 "sha256:ff6f3db31555657f3163b15a6b7c6938d08df7adbfc9dd13d9d19edad678f1e8"
             ],
-            "markers": "python_full_version >= '3.6.0'",
             "version": "==3.0.1"
         },
         "click": {
@@ -596,18 +625,18 @@
         },
         "docutils": {
             "hashes": [
-                "sha256:33995a6753c30b7f577febfc2c50411fec6aac7f7ffeb7c4cfe5991072dcf9e6",
-                "sha256:5e1de4d849fee02c63b040a4a3fd567f4ab104defd8a5511fbbc24a8a017efbc"
+                "sha256:686577d2e4c32380bb50cbb22f575ed742d58168cee37e99117a854bcd88f125",
+                "sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==0.19"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==0.17.1"
         },
         "editables": {
             "hashes": [
                 "sha256:167524e377358ed1f1374e61c268f0d7a4bf7dbd046c656f7b410cde16161b1a",
                 "sha256:ee686a8db9f5d91da39849f175ffeef094dd0e9c36d6a59a2e8c7f92a3b80020"
             ],
-            "markers": "python_version >= '3.1'",
+            "markers": "python_version > '3'",
             "version": "==0.3"
         },
         "exceptiongroup": {
@@ -810,7 +839,7 @@
                 "sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2",
                 "sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"
             ],
-            "markers": "python_version >= '3.1'",
+            "markers": "python_version > '3'",
             "version": "==23.0"
         },
         "pathspec": {
@@ -842,7 +871,7 @@
                 "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
                 "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
             ],
-            "markers": "python_version >= '3.1'",
+            "markers": "python_version > '3'",
             "version": "==1.0.0"
         },
         "pre-commit": {
@@ -987,19 +1016,19 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:0dac3b698538ffef41716cf97ba26c1c7788dba73ce6f150c1ff5b4720786dd2",
-                "sha256:807d1cb3d6be87eb78a381c3e70ebd8d346b9a25f3753e9947e866b2786865fc"
+                "sha256:060ca5c9f7ba57a08a1219e547b269fadf125ae25b06b9fa7f66768efb652d6d",
+                "sha256:51026de0a9ff9fc13c05d74913ad66047e104f56a129ff73e174eb5c3ee794b5"
             ],
             "index": "pypi",
-            "version": "==6.1.3"
+            "version": "==5.3.0"
         },
         "sphinx-rtd-theme": {
             "hashes": [
-                "sha256:eda689eda0c7301a80cf122dad28b1861e5605cbf455558f3775e1e8200e83a5",
-                "sha256:fa6bebd5ab9a73da8e102509a86f3fcc36dec04a0b52ea80e5a033b2aba00113"
+                "sha256:31faa07d3e97c8955637fc3f1423a5ab2c44b74b8cc558a51498c202ce5cbda7",
+                "sha256:6146c845f1e1947b3c3dd4432c28998a1693ccc742b4f9ad7c63129f0757c103"
             ],
             "index": "pypi",
-            "version": "==0.5.1"
+            "version": "==1.1.1"
         },
         "sphinxcontrib-applehelp": {
             "hashes": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "requests",
   "rich",
   "rich-click",
-  "securesystemslib",
+  "securesystemslib[crypto]",
   "tuf==2.0.0",
 ]
 dynamic = ["version"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,55 +1,55 @@
 -i https://pypi.org/simple
-alabaster==0.7.13 ; python_version >= '3.6'
-attrs==22.2.0 ; python_version >= '3.6'
-babel==2.11.0 ; python_version >= '3.6'
+alabaster==0.7.13; python_version >= '3.6'
+attrs==22.2.0; python_version >= '3.6'
+babel==2.11.0; python_version >= '3.6'
 black==22.3.0
 build==0.10.0
-cachetools==5.3.0 ; python_version ~= '3.7'
-certifi==2022.12.7 ; python_version >= '3.6'
-cfgv==3.3.1 ; python_full_version >= '3.6.1'
-chardet==5.1.0 ; python_version >= '3.7'
-charset-normalizer==3.0.1 ; python_full_version >= '3.6.0'
+cachetools==5.3.0; python_version ~= '3.7'
+certifi==2022.12.7; python_version >= '3.6'
+cfgv==3.3.1; python_full_version >= '3.6.1'
+chardet==5.1.0; python_version >= '3.7'
+charset-normalizer==3.0.1
 click==8.1.3
-colorama==0.4.6 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
+colorama==0.4.6; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
 coverage==7.0.5
 distlib==0.3.6
-docutils==0.19 ; python_version >= '3.7'
-editables==0.3 ; python_version >= '3.1'
-exceptiongroup==1.1.0 ; python_version < '3.11'
-filelock==3.9.0 ; python_version >= '3.7'
+docutils==0.17.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+editables==0.3; python_version > '3'
+exceptiongroup==1.1.0; python_version < '3.11'
+filelock==3.9.0; python_version >= '3.7'
 flake8==6.0.0
 hatchling==0.22.0
-identify==2.5.15 ; python_version >= '3.7'
-idna==3.4 ; python_version >= '3.5'
-imagesize==1.4.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-iniconfig==2.0.0 ; python_version >= '3.7'
+identify==2.5.15; python_version >= '3.7'
+idna==3.4; python_version >= '3.5'
+imagesize==1.4.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+iniconfig==2.0.0; python_version >= '3.7'
 isort==5.11.4
-jinja2==3.1.2 ; python_version >= '3.7'
-markupsafe==2.1.2 ; python_version >= '3.7'
-mccabe==0.7.0 ; python_version >= '3.6'
+jinja2==3.1.2; python_version >= '3.7'
+markupsafe==2.1.2; python_version >= '3.7'
+mccabe==0.7.0; python_version >= '3.6'
 mypy==0.991
 mypy-extensions==0.4.3
-nodeenv==1.7.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
-packaging==23.0 ; python_version >= '3.1'
-pathspec==0.10.3 ; python_version >= '3.7'
+nodeenv==1.7.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
+packaging==23.0; python_version > '3'
+pathspec==0.10.3; python_version >= '3.7'
 pip==22.3.1
-platformdirs==2.6.2 ; python_version >= '3.7'
-pluggy==1.0.0 ; python_version >= '3.1'
+platformdirs==2.6.2; python_version >= '3.7'
+pluggy==1.0.0; python_version > '3'
 pre-commit==3.0.0
 pretend==1.0.9
-pycodestyle==2.10.0 ; python_version >= '3.6'
-pyflakes==3.0.1 ; python_version >= '3.6'
-pygments==2.14.0 ; python_version >= '3.6'
-pyproject-api==1.5.0 ; python_version >= '3.7'
-pyproject-hooks==1.0.0 ; python_version >= '3.7'
+pycodestyle==2.10.0; python_version >= '3.6'
+pyflakes==3.0.1; python_version >= '3.6'
+pygments==2.14.0; python_version >= '3.6'
+pyproject-api==1.5.0; python_version >= '3.7'
+pyproject-hooks==1.0.0; python_version >= '3.7'
 pytest==7.2.1
 pytz==2022.7.1
-pyyaml==6.0 ; python_version >= '3.6'
+pyyaml==6.0; python_version >= '3.6'
 requests==2.28.2
-setuptools==66.1.1 ; python_version >= '3.7'
+setuptools==66.1.1; python_version >= '3.7'
 snowballstemmer==2.2.0
-sphinx==6.1.3
-sphinx-rtd-theme==0.5.1
+sphinx==5.3.0
+sphinx-rtd-theme==1.1.1
 sphinxcontrib-applehelp==1.0.4
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.0
@@ -57,20 +57,21 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-plantuml==0.24.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
-tomli==2.0.1 ; python_version < '3.11'
+tomli==2.0.1; python_version < '3.11'
 tox==4.3.5
-typing-extensions==4.4.0 ; python_version >= '3.7'
-urllib3==1.26.14 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
-virtualenv==20.17.1 ; python_version >= '3.6'
+typing-extensions==4.4.0; python_version >= '3.7'
+urllib3==1.26.14; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
+virtualenv==20.17.1; python_version >= '3.6'
 cffi==1.15.1
 configobj==5.0.8
+cryptography==39.0.0
 dynaconf[ini]==3.1.11
-markdown-it-py==2.1.0 ; python_version >= '3.7'
-mdurl==0.1.2 ; python_version >= '3.7'
+markdown-it-py==2.1.0; python_version >= '3.7'
+mdurl==0.1.2; python_version >= '3.7'
 pycparser==2.21
 pynacl==1.5.0
 rich==13.2.0
 rich-click==1.6.1
-securesystemslib==0.26.0
-six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+securesystemslib[crypto]==0.26.0
+six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
 tuf==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,21 @@
 -i https://pypi.org/simple
-certifi==2022.12.7 ; python_version >= '3.6'
+certifi==2022.12.7; python_version >= '3.6'
 cffi==1.15.1
-charset-normalizer==3.0.1 ; python_full_version >= '3.6.0'
+charset-normalizer==3.0.1
 click==8.1.3
 configobj==5.0.8
+cryptography==39.0.0
 dynaconf[ini]==3.1.11
-idna==3.4 ; python_version >= '3.5'
-markdown-it-py==2.1.0 ; python_version >= '3.7'
-mdurl==0.1.2 ; python_version >= '3.7'
+idna==3.4; python_version >= '3.5'
+markdown-it-py==2.1.0; python_version >= '3.7'
+mdurl==0.1.2; python_version >= '3.7'
 pycparser==2.21
-pygments==2.14.0 ; python_version >= '3.6'
+pygments==2.14.0; python_version >= '3.6'
 pynacl==1.5.0
 requests==2.28.2
 rich==13.2.0
 rich-click==1.6.1
-securesystemslib==0.26.0
-six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+securesystemslib[crypto]==0.26.0
+six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
 tuf==2.0.0
-urllib3==1.26.14 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
+urllib3==1.26.14; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'


### PR DESCRIPTION
The `cryptography` package is a dependency of the `securesystemslib` package, to be exact it is an _optional_ dependency. `securesystemslib` uses "optional dependencies" ("extras") to allow a default installation with limited capabilities.
However, since we are making use of the `cryptography` library via `securesystemslib`, we need to install at least the `crypto` extra.

With my PR fix I don't see this error, but following the same steps as above I get:
```shell
❌ Failed: Invalid encrypted file. Check the password.
```
This might have to do with my key however, can someone verify the fix from their side?

Fixes #131

Signed-off-by: Konstantinos Papadopoulos <konpap1996@yahoo.com>