### PR TITLE
Add bandit pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,12 @@ repos:
   hooks:
   - id: black
     args: [-l79, --check, --diff, .]
+- repo: https://github.com/PyCQA/bandit
+  rev: '1.7.4'
+  hooks:
+  - id: bandit
+    args: ["-r", "repository_service_tuf"]
+    exclude: tests
 - repo: local
   hooks:
     - id: tox-requirements

--- a/Pipfile
+++ b/Pipfile
@@ -35,6 +35,7 @@ sphinx-rtd-theme = "*"
 hatchling = "==0.22.0"
 build = "*"
 pre-commit = "*"
+bandit = "*"
 
 [requires]
 python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "456475e724cae26ff549b8125553f181e05eab5a671546d909ab03c7367a55e5"
+            "sha256": "cf9901cce4dd1c00586e1d98fffc8479fd00b17e69ccd2a5bc0ad11f32dae5b6"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -336,7 +336,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "tuf": {
@@ -380,6 +380,14 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==2.11.0"
+        },
+        "bandit": {
+            "hashes": [
+                "sha256:2d63a8c573417bae338962d4b9b06fbc6080f74ecd955a092849e1e65c717bd2",
+                "sha256:412d3f259dab4077d0e7f0c11f50f650cc7d10db905d98f6520a95a18049658a"
+            ],
+            "index": "pypi",
+            "version": "==1.7.4"
         },
         "black": {
             "hashes": [
@@ -561,60 +569,60 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:051afcbd6d2ac39298d62d340f94dbb6a1f31de06dfaf6fcef7b759dd3860c45",
-                "sha256:0a1890fca2962c4f1ad16551d660b46ea77291fba2cc21c024cd527b9d9c8809",
-                "sha256:0ee30375b409d9a7ea0f30c50645d436b6f5dfee254edffd27e45a980ad2c7f4",
-                "sha256:13250b1f0bd023e0c9f11838bdeb60214dd5b6aaf8e8d2f110c7e232a1bff83b",
-                "sha256:17e01dd8666c445025c29684d4aabf5a90dc6ef1ab25328aa52bedaa95b65ad7",
-                "sha256:19245c249aa711d954623d94f23cc94c0fd65865661f20b7781210cb97c471c0",
-                "sha256:1caed2367b32cc80a2b7f58a9f46658218a19c6cfe5bc234021966dc3daa01f0",
-                "sha256:1f66862d3a41674ebd8d1a7b6f5387fe5ce353f8719040a986551a545d7d83ea",
-                "sha256:220e3fa77d14c8a507b2d951e463b57a1f7810a6443a26f9b7591ef39047b1b2",
-                "sha256:276f4cd0001cd83b00817c8db76730938b1ee40f4993b6a905f40a7278103b3a",
-                "sha256:29de916ba1099ba2aab76aca101580006adfac5646de9b7c010a0f13867cba45",
-                "sha256:2a7f23bbaeb2a87f90f607730b45564076d870f1fb07b9318d0c21f36871932b",
-                "sha256:2c407b1950b2d2ffa091f4e225ca19a66a9bd81222f27c56bd12658fc5ca1209",
-                "sha256:30b5fec1d34cc932c1bc04017b538ce16bf84e239378b8f75220478645d11fca",
-                "sha256:3c2155943896ac78b9b0fd910fb381186d0c345911f5333ee46ac44c8f0e43ab",
-                "sha256:411d4ff9d041be08fdfc02adf62e89c735b9468f6d8f6427f8a14b6bb0a85095",
-                "sha256:436e103950d05b7d7f55e39beeb4d5be298ca3e119e0589c0227e6d0b01ee8c7",
-                "sha256:49640bda9bda35b057b0e65b7c43ba706fa2335c9a9896652aebe0fa399e80e6",
-                "sha256:4a950f83fd3f9bca23b77442f3a2b2ea4ac900944d8af9993743774c4fdc57af",
-                "sha256:50a6adc2be8edd7ee67d1abc3cd20678987c7b9d79cd265de55941e3d0d56499",
-                "sha256:52ab14b9e09ce052237dfe12d6892dd39b0401690856bcfe75d5baba4bfe2831",
-                "sha256:54f7e9705e14b2c9f6abdeb127c390f679f6dbe64ba732788d3015f7f76ef637",
-                "sha256:66e50680e888840c0995f2ad766e726ce71ca682e3c5f4eee82272c7671d38a2",
-                "sha256:790e4433962c9f454e213b21b0fd4b42310ade9c077e8edcb5113db0818450cb",
-                "sha256:7a38362528a9115a4e276e65eeabf67dcfaf57698e17ae388599568a78dcb029",
-                "sha256:7b05ed4b35bf6ee790832f68932baf1f00caa32283d66cc4d455c9e9d115aafc",
-                "sha256:7e109f1c9a3ece676597831874126555997c48f62bddbcace6ed17be3e372de8",
-                "sha256:949844af60ee96a376aac1ded2a27e134b8c8d35cc006a52903fc06c24a3296f",
-                "sha256:95304068686545aa368b35dfda1cdfbbdbe2f6fe43de4a2e9baa8ebd71be46e2",
-                "sha256:9e662e6fc4f513b79da5d10a23edd2b87685815b337b1a30cd11307a6679148d",
-                "sha256:a9fed35ca8c6e946e877893bbac022e8563b94404a605af1d1e6accc7eb73289",
-                "sha256:b69522b168a6b64edf0c33ba53eac491c0a8f5cc94fa4337f9c6f4c8f2f5296c",
-                "sha256:b78729038abea6a5df0d2708dce21e82073463b2d79d10884d7d591e0f385ded",
-                "sha256:b8c56bec53d6e3154eaff6ea941226e7bd7cc0d99f9b3756c2520fc7a94e6d96",
-                "sha256:b9727ac4f5cf2cbf87880a63870b5b9730a8ae3a4a360241a0fdaa2f71240ff0",
-                "sha256:ba3027deb7abf02859aca49c865ece538aee56dcb4871b4cced23ba4d5088904",
-                "sha256:be9fcf32c010da0ba40bf4ee01889d6c737658f4ddff160bd7eb9cac8f094b21",
-                "sha256:c18d47f314b950dbf24a41787ced1474e01ca816011925976d90a88b27c22b89",
-                "sha256:c76a3075e96b9c9ff00df8b5f7f560f5634dffd1658bafb79eb2682867e94f78",
-                "sha256:cbfcba14a3225b055a28b3199c3d81cd0ab37d2353ffd7f6fd64844cebab31ad",
-                "sha256:d254666d29540a72d17cc0175746cfb03d5123db33e67d1020e42dae611dc196",
-                "sha256:d66187792bfe56f8c18ba986a0e4ae44856b1c645336bd2c776e3386da91e1dd",
-                "sha256:d8d04e755934195bdc1db45ba9e040b8d20d046d04d6d77e71b3b34a8cc002d0",
-                "sha256:d8f3e2e0a1d6777e58e834fd5a04657f66affa615dae61dd67c35d1568c38882",
-                "sha256:e057e74e53db78122a3979f908973e171909a58ac20df05c33998d52e6d35757",
-                "sha256:e4ce984133b888cc3a46867c8b4372c7dee9cee300335e2925e197bcd45b9e16",
-                "sha256:ea76dbcad0b7b0deb265d8c36e0801abcddf6cc1395940a24e3595288b405ca0",
-                "sha256:ecb0f73954892f98611e183f50acdc9e21a4653f294dfbe079da73c6378a6f47",
-                "sha256:ef14d75d86f104f03dea66c13188487151760ef25dd6b2dbd541885185f05f40",
-                "sha256:f26648e1b3b03b6022b48a9b910d0ae209e2d51f50441db5dce5b530fad6d9b1",
-                "sha256:f67472c09a0c7486e27f3275f617c964d25e35727af952869dd496b9b5b7f6a3"
+                "sha256:04481245ef966fbd24ae9b9e537ce899ae584d521dfbe78f89cad003c38ca2ab",
+                "sha256:0c45948f613d5d18c9ec5eaa203ce06a653334cf1bd47c783a12d0dd4fd9c851",
+                "sha256:10188fe543560ec4874f974b5305cd1a8bdcfa885ee00ea3a03733464c4ca265",
+                "sha256:218fe982371ac7387304153ecd51205f14e9d731b34fb0568181abaf7b443ba0",
+                "sha256:29571503c37f2ef2138a306d23e7270687c0efb9cab4bd8038d609b5c2393a3a",
+                "sha256:2a60d6513781e87047c3e630b33b4d1e89f39836dac6e069ffee28c4786715f5",
+                "sha256:2bf1d5f2084c3932b56b962a683074a3692bce7cabd3aa023c987a2a8e7612f6",
+                "sha256:3164d31078fa9efe406e198aecd2a02d32a62fecbdef74f76dad6a46c7e48311",
+                "sha256:32df215215f3af2c1617a55dbdfb403b772d463d54d219985ac7cd3bf124cada",
+                "sha256:33d1ae9d4079e05ac4cc1ef9e20c648f5afabf1a92adfaf2ccf509c50b85717f",
+                "sha256:33ff26d0f6cc3ca8de13d14fde1ff8efe1456b53e3f0273e63cc8b3c84a063d8",
+                "sha256:38da2db80cc505a611938d8624801158e409928b136c8916cd2e203970dde4dc",
+                "sha256:3b155caf3760408d1cb903b21e6a97ad4e2bdad43cbc265e3ce0afb8e0057e73",
+                "sha256:3b946bbcd5a8231383450b195cfb58cb01cbe7f8949f5758566b881df4b33baf",
+                "sha256:3baf5f126f30781b5e93dbefcc8271cb2491647f8283f20ac54d12161dff080e",
+                "sha256:4b14d5e09c656de5038a3f9bfe5228f53439282abcab87317c9f7f1acb280352",
+                "sha256:51b236e764840a6df0661b67e50697aaa0e7d4124ca95e5058fa3d7cbc240b7c",
+                "sha256:63ffd21aa133ff48c4dff7adcc46b7ec8b565491bfc371212122dd999812ea1c",
+                "sha256:6a43c7823cd7427b4ed763aa7fb63901ca8288591323b58c9cd6ec31ad910f3c",
+                "sha256:755e89e32376c850f826c425ece2c35a4fc266c081490eb0a841e7c1cb0d3bda",
+                "sha256:7a726d742816cb3a8973c8c9a97539c734b3a309345236cd533c4883dda05b8d",
+                "sha256:7c7c0d0827e853315c9bbd43c1162c006dd808dbbe297db7ae66cd17b07830f0",
+                "sha256:7ed681b0f8e8bcbbffa58ba26fcf5dbc8f79e7997595bf071ed5430d8c08d6f3",
+                "sha256:7ee5c9bb51695f80878faaa5598040dd6c9e172ddcf490382e8aedb8ec3fec8d",
+                "sha256:8361be1c2c073919500b6601220a6f2f98ea0b6d2fec5014c1d9cfa23dd07038",
+                "sha256:8ae125d1134bf236acba8b83e74c603d1b30e207266121e76484562bc816344c",
+                "sha256:9817733f0d3ea91bea80de0f79ef971ae94f81ca52f9b66500c6a2fea8e4b4f8",
+                "sha256:98b85dd86514d889a2e3dd22ab3c18c9d0019e696478391d86708b805f4ea0fa",
+                "sha256:9ccb092c9ede70b2517a57382a601619d20981f56f440eae7e4d7eaafd1d1d09",
+                "sha256:9d58885215094ab4a86a6aef044e42994a2bd76a446dc59b352622655ba6621b",
+                "sha256:b643cb30821e7570c0aaf54feaf0bfb630b79059f85741843e9dc23f33aaca2c",
+                "sha256:bc7c85a150501286f8b56bd8ed3aa4093f4b88fb68c0843d21ff9656f0009d6a",
+                "sha256:beeb129cacea34490ffd4d6153af70509aa3cda20fdda2ea1a2be870dfec8d52",
+                "sha256:c31b75ae466c053a98bf26843563b3b3517b8f37da4d47b1c582fdc703112bc3",
+                "sha256:c4e4881fa9e9667afcc742f0c244d9364d197490fbc91d12ac3b5de0bf2df146",
+                "sha256:c5b15ed7644ae4bee0ecf74fee95808dcc34ba6ace87e8dfbf5cb0dc20eab45a",
+                "sha256:d12d076582507ea460ea2a89a8c85cb558f83406c8a41dd641d7be9a32e1274f",
+                "sha256:d248cd4a92065a4d4543b8331660121b31c4148dd00a691bfb7a5cdc7483cfa4",
+                "sha256:d47dd659a4ee952e90dc56c97d78132573dc5c7b09d61b416a9deef4ebe01a0c",
+                "sha256:d4a5a5879a939cb84959d86869132b00176197ca561c664fc21478c1eee60d75",
+                "sha256:da9b41d4539eefd408c46725fb76ecba3a50a3367cafb7dea5f250d0653c1040",
+                "sha256:db61a79c07331e88b9a9974815c075fbd812bc9dbc4dc44b366b5368a2936063",
+                "sha256:ddb726cb861c3117a553f940372a495fe1078249ff5f8a5478c0576c7be12050",
+                "sha256:ded59300d6330be27bc6cf0b74b89ada58069ced87c48eaf9344e5e84b0072f7",
+                "sha256:e2617759031dae1bf183c16cef8fcfb3de7617f394c813fa5e8e46e9b82d4222",
+                "sha256:e5cdbb5cafcedea04924568d990e20ce7f1945a1dd54b560f879ee2d57226912",
+                "sha256:ec8e767f13be637d056f7e07e61d089e555f719b387a7070154ad80a0ff31801",
+                "sha256:ef382417db92ba23dfb5864a3fc9be27ea4894e86620d342a116b243ade5d35d",
+                "sha256:f2cba5c6db29ce991029b5e4ac51eb36774458f0a3b8d3137241b32d1bb91f06",
+                "sha256:f5b4198d85a3755d27e64c52f8c95d6333119e49fd001ae5798dac872c95e0f8",
+                "sha256:ffeeb38ee4a80a30a6877c5c4c359e5498eec095878f1581453202bfacc8fbc2"
             ],
             "index": "pypi",
-            "version": "==7.0.5"
+            "version": "==7.1.0"
         },
         "distlib": {
             "hashes": [
@@ -625,18 +633,18 @@
         },
         "docutils": {
             "hashes": [
-                "sha256:686577d2e4c32380bb50cbb22f575ed742d58168cee37e99117a854bcd88f125",
-                "sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61"
+                "sha256:33995a6753c30b7f577febfc2c50411fec6aac7f7ffeb7c4cfe5991072dcf9e6",
+                "sha256:5e1de4d849fee02c63b040a4a3fd567f4ab104defd8a5511fbbc24a8a017efbc"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==0.17.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==0.19"
         },
         "editables": {
             "hashes": [
                 "sha256:167524e377358ed1f1374e61c268f0d7a4bf7dbd046c656f7b410cde16161b1a",
                 "sha256:ee686a8db9f5d91da39849f175ffeef094dd0e9c36d6a59a2e8c7f92a3b80020"
             ],
-            "markers": "python_version > '3'",
+            "markers": "python_version >= '3.1'",
             "version": "==0.3"
         },
         "exceptiongroup": {
@@ -662,6 +670,22 @@
             ],
             "index": "pypi",
             "version": "==6.0.0"
+        },
+        "gitdb": {
+            "hashes": [
+                "sha256:6eb990b69df4e15bad899ea868dc46572c3f75339735663b81de79b06f17eb9a",
+                "sha256:c286cf298426064079ed96a9e4a9d39e7f3e9bf15ba60701e95f5492f28415c7"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==4.0.10"
+        },
+        "gitpython": {
+            "hashes": [
+                "sha256:769c2d83e13f5d938b7688479da374c4e3d49f71549aaf462b646db9602ea6f8",
+                "sha256:cd455b0000615c60e286208ba540271af9fe531fa6a87cc590a7298785ab2882"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.1.30"
         },
         "hatchling": {
             "hashes": [
@@ -839,16 +863,24 @@
                 "sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2",
                 "sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"
             ],
-            "markers": "python_version > '3'",
+            "markers": "python_version >= '3.1'",
             "version": "==23.0"
         },
         "pathspec": {
             "hashes": [
-                "sha256:3c95343af8b756205e2aba76e843ba9520a24dd84f68c22b9f93251507509dd6",
-                "sha256:56200de4077d9d0791465aa9095a01d421861e405b5096955051deefd697d6f6"
+                "sha256:3a66eb970cbac598f9e5ccb5b2cf58930cd8e3ed86d393d541eaf2d8b1705229",
+                "sha256:64d338d4e0914e91c1792321e6907b5a593f1ab1851de7fc269557a21b30ebbc"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.10.3"
+            "version": "==0.11.0"
+        },
+        "pbr": {
+            "hashes": [
+                "sha256:567f09558bae2b3ab53cb3c1e2e33e726ff3338e7bae3db5dc954b3a44eef12b",
+                "sha256:aefc51675b0b533d56bb5fd1c8c6c0522fe31896679882e1c4c63d5e4a0fccb3"
+            ],
+            "markers": "python_version >= '2.6'",
+            "version": "==5.11.1"
         },
         "pip": {
             "hashes": [
@@ -871,7 +903,7 @@
                 "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
                 "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
             ],
-            "markers": "python_version > '3'",
+            "markers": "python_version >= '3.1'",
             "version": "==1.0.0"
         },
         "pre-commit": {
@@ -1007,6 +1039,14 @@
             "markers": "python_version >= '3.7'",
             "version": "==66.1.1"
         },
+        "smmap": {
+            "hashes": [
+                "sha256:2aba19d6a040e78d8b09de5c57e96207b09ed71d8e55ce0959eeee6c8e190d94",
+                "sha256:c840e62059cd3be204b0c9c9f74be2c09d5648eddd4580d9314c3ecde0b30936"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==5.0.0"
+        },
         "snowballstemmer": {
             "hashes": [
                 "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1",
@@ -1016,19 +1056,19 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:060ca5c9f7ba57a08a1219e547b269fadf125ae25b06b9fa7f66768efb652d6d",
-                "sha256:51026de0a9ff9fc13c05d74913ad66047e104f56a129ff73e174eb5c3ee794b5"
+                "sha256:0dac3b698538ffef41716cf97ba26c1c7788dba73ce6f150c1ff5b4720786dd2",
+                "sha256:807d1cb3d6be87eb78a381c3e70ebd8d346b9a25f3753e9947e866b2786865fc"
             ],
             "index": "pypi",
-            "version": "==5.3.0"
+            "version": "==6.1.3"
         },
         "sphinx-rtd-theme": {
             "hashes": [
-                "sha256:31faa07d3e97c8955637fc3f1423a5ab2c44b74b8cc558a51498c202ce5cbda7",
-                "sha256:6146c845f1e1947b3c3dd4432c28998a1693ccc742b4f9ad7c63129f0757c103"
+                "sha256:eda689eda0c7301a80cf122dad28b1861e5605cbf455558f3775e1e8200e83a5",
+                "sha256:fa6bebd5ab9a73da8e102509a86f3fcc36dec04a0b52ea80e5a033b2aba00113"
             ],
             "index": "pypi",
-            "version": "==1.1.1"
+            "version": "==0.5.1"
         },
         "sphinxcontrib-applehelp": {
             "hashes": [
@@ -1084,6 +1124,14 @@
             ],
             "index": "pypi",
             "version": "==1.1.5"
+        },
+        "stevedore": {
+            "hashes": [
+                "sha256:7f8aeb6e3f90f96832c301bff21a7eb5eefbe894c88c506483d355565d88cc1a",
+                "sha256:aa6436565c069b2946fe4ebff07f5041e0c8bf18c7376dd29edf80cf7d524e4e"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==4.1.1"
         },
         "tomli": {
             "hashes": [

--- a/repository_service_tuf/helpers/api_client.py
+++ b/repository_service_tuf/helpers/api_client.py
@@ -12,7 +12,7 @@ from repository_service_tuf.cli import click
 
 
 class URL(Enum):
-    token = "api/v1/token/"
+    token = "api/v1/token/"  # nosec
     bootstrap = "api/v1/bootstrap/"
     task = "api/v1/task/?task_id="
 

--- a/repository_service_tuf/helpers/api_client.py
+++ b/repository_service_tuf/helpers/api_client.py
@@ -12,7 +12,7 @@ from repository_service_tuf.cli import click
 
 
 class URL(Enum):
-    token = "api/v1/token/"  # nosec
+    token = "api/v1/token/"  # nosec bandit: not hard coded password.
     bootstrap = "api/v1/bootstrap/"
     task = "api/v1/task/?task_id="
 

--- a/repository_service_tuf/helpers/tuf.py
+++ b/repository_service_tuf/helpers/tuf.py
@@ -175,10 +175,11 @@ def initialize_metadata(
         # bootstrapping the metadata, because in production we do not have
         # access to all top-level role signing keys at the time of
         # bootstrapping the metadata.
-        assert len(signers) >= threshold, (
-            f"not enough keys ({len(signers)}) for "
-            f"signing threshold '{threshold}'"
-        )
+        if len(signers) >= threshold:
+            raise ValueError(
+                f"not enough keys ({len(signers)}) for "
+                f"signing threshold '{threshold}'"
+            )
 
         root.roles[role_name] = Role([], threshold)
         for signer in signers:

--- a/repository_service_tuf/helpers/tuf.py
+++ b/repository_service_tuf/helpers/tuf.py
@@ -175,7 +175,7 @@ def initialize_metadata(
         # bootstrapping the metadata, because in production we do not have
         # access to all top-level role signing keys at the time of
         # bootstrapping the metadata.
-        if len(signers) >= threshold:
+        if len(signers) < threshold:
             raise ValueError(
                 f"not enough keys ({len(signers)}) for "
                 f"signing threshold '{threshold}'"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,55 +1,60 @@
 -i https://pypi.org/simple
-alabaster==0.7.13; python_version >= '3.6'
-attrs==22.2.0; python_version >= '3.6'
-babel==2.11.0; python_version >= '3.6'
+alabaster==0.7.13 ; python_version >= '3.6'
+attrs==22.2.0 ; python_version >= '3.6'
+babel==2.11.0 ; python_version >= '3.6'
+bandit==1.7.4
 black==22.3.0
 build==0.10.0
-cachetools==5.3.0; python_version ~= '3.7'
-certifi==2022.12.7; python_version >= '3.6'
-cfgv==3.3.1; python_full_version >= '3.6.1'
-chardet==5.1.0; python_version >= '3.7'
+cachetools==5.3.0 ; python_version ~= '3.7'
+certifi==2022.12.7 ; python_version >= '3.6'
+cfgv==3.3.1 ; python_full_version >= '3.6.1'
+chardet==5.1.0 ; python_version >= '3.7'
 charset-normalizer==3.0.1
 click==8.1.3
-colorama==0.4.6; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
-coverage==7.0.5
+colorama==0.4.6 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
+coverage==7.1.0
 distlib==0.3.6
-docutils==0.17.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-editables==0.3; python_version > '3'
-exceptiongroup==1.1.0; python_version < '3.11'
-filelock==3.9.0; python_version >= '3.7'
+docutils==0.19 ; python_version >= '3.7'
+editables==0.3 ; python_version >= '3.1'
+exceptiongroup==1.1.0 ; python_version < '3.11'
+filelock==3.9.0 ; python_version >= '3.7'
 flake8==6.0.0
+gitdb==4.0.10 ; python_version >= '3.7'
+gitpython==3.1.30 ; python_version >= '3.7'
 hatchling==0.22.0
-identify==2.5.15; python_version >= '3.7'
-idna==3.4; python_version >= '3.5'
-imagesize==1.4.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-iniconfig==2.0.0; python_version >= '3.7'
+identify==2.5.15 ; python_version >= '3.7'
+idna==3.4 ; python_version >= '3.5'
+imagesize==1.4.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+iniconfig==2.0.0 ; python_version >= '3.7'
 isort==5.11.4
-jinja2==3.1.2; python_version >= '3.7'
-markupsafe==2.1.2; python_version >= '3.7'
-mccabe==0.7.0; python_version >= '3.6'
+jinja2==3.1.2 ; python_version >= '3.7'
+markupsafe==2.1.2 ; python_version >= '3.7'
+mccabe==0.7.0 ; python_version >= '3.6'
 mypy==0.991
 mypy-extensions==0.4.3
-nodeenv==1.7.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
-packaging==23.0; python_version > '3'
-pathspec==0.10.3; python_version >= '3.7'
+nodeenv==1.7.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
+packaging==23.0 ; python_version >= '3.1'
+pathspec==0.11.0 ; python_version >= '3.7'
+pbr==5.11.1 ; python_version >= '2.6'
 pip==22.3.1
-platformdirs==2.6.2; python_version >= '3.7'
-pluggy==1.0.0; python_version > '3'
+platformdirs==2.6.2 ; python_version >= '3.7'
+pluggy==1.0.0 ; python_version >= '3.1'
 pre-commit==3.0.0
 pretend==1.0.9
-pycodestyle==2.10.0; python_version >= '3.6'
-pyflakes==3.0.1; python_version >= '3.6'
-pygments==2.14.0; python_version >= '3.6'
-pyproject-api==1.5.0; python_version >= '3.7'
-pyproject-hooks==1.0.0; python_version >= '3.7'
+pycodestyle==2.10.0 ; python_version >= '3.6'
+pyflakes==3.0.1 ; python_version >= '3.6'
+pygments==2.14.0 ; python_version >= '3.6'
+pyproject-api==1.5.0 ; python_version >= '3.7'
+pyproject-hooks==1.0.0 ; python_version >= '3.7'
 pytest==7.2.1
 pytz==2022.7.1
-pyyaml==6.0; python_version >= '3.6'
+pyyaml==6.0 ; python_version >= '3.6'
 requests==2.28.2
-setuptools==66.1.1; python_version >= '3.7'
+setuptools==66.1.1 ; python_version >= '3.7'
+smmap==5.0.0 ; python_version >= '3.6'
 snowballstemmer==2.2.0
-sphinx==5.3.0
-sphinx-rtd-theme==1.1.1
+sphinx==6.1.3
+sphinx-rtd-theme==0.5.1
 sphinxcontrib-applehelp==1.0.4
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.0
@@ -57,21 +62,22 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-plantuml==0.24.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
-tomli==2.0.1; python_version < '3.11'
+stevedore==4.1.1 ; python_version >= '3.8'
+tomli==2.0.1 ; python_version < '3.11'
 tox==4.3.5
-typing-extensions==4.4.0; python_version >= '3.7'
-urllib3==1.26.14; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
-virtualenv==20.17.1; python_version >= '3.6'
+typing-extensions==4.4.0 ; python_version >= '3.7'
+urllib3==1.26.14 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
+virtualenv==20.17.1 ; python_version >= '3.6'
 cffi==1.15.1
 configobj==5.0.8
 cryptography==39.0.0
 dynaconf[ini]==3.1.11
-markdown-it-py==2.1.0; python_version >= '3.7'
-mdurl==0.1.2; python_version >= '3.7'
+markdown-it-py==2.1.0 ; python_version >= '3.7'
+mdurl==0.1.2 ; python_version >= '3.7'
 pycparser==2.21
 pynacl==1.5.0
 rich==13.2.0
 rich-click==1.6.1
 securesystemslib[crypto]==0.26.0
-six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
+six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 tuf==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,21 +1,21 @@
 -i https://pypi.org/simple
-certifi==2022.12.7; python_version >= '3.6'
+certifi==2022.12.7 ; python_version >= '3.6'
 cffi==1.15.1
 charset-normalizer==3.0.1
 click==8.1.3
 configobj==5.0.8
 cryptography==39.0.0
 dynaconf[ini]==3.1.11
-idna==3.4; python_version >= '3.5'
-markdown-it-py==2.1.0; python_version >= '3.7'
-mdurl==0.1.2; python_version >= '3.7'
+idna==3.4 ; python_version >= '3.5'
+markdown-it-py==2.1.0 ; python_version >= '3.7'
+mdurl==0.1.2 ; python_version >= '3.7'
 pycparser==2.21
-pygments==2.14.0; python_version >= '3.6'
+pygments==2.14.0 ; python_version >= '3.6'
 pynacl==1.5.0
 requests==2.28.2
 rich==13.2.0
 rich-click==1.6.1
 securesystemslib[crypto]==0.26.0
-six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
+six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 tuf==2.0.0
-urllib3==1.26.14; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
+urllib3==1.26.14 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ commands =
     pre-commit run flake8 --all-files --show-diff-on-failure
     pre-commit run isort --all-files --show-diff-on-failure
     pre-commit run black --all-files --show-diff-on-failure
+    pre-commit run bandit --all-files --show-diff-on-failure
     # mypy . #issue33
 
 [testenv:test]


### PR DESCRIPTION
To achieve the OpenSSF Best Practices badge, we need to implement
the static code analysis tool.

This commit adds the `bandit` to the RSTUF CLI.