### PR TITLE
feature: import targets

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,8 @@ requests = "*"
 tuf = "==2.0.0"
 dynaconf = {extras = ["ini"], version = "*"}
 isort = "*"
+sqlalchemy = "*"
+psycopg2 = "*"
 
 [dev-packages]
 black = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "73a082dc6f92fb13af3e8f0357fb5f1577e8134e253ce914e420533e0c4e5e30"
+            "sha256": "458a229a12808fb1a4797d0fae298fbc85106e59e59b18d7887279e8e4412b2c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -241,6 +241,72 @@
             "index": "pypi",
             "version": "==3.1.11"
         },
+        "greenlet": {
+            "hashes": [
+                "sha256:03a8f4f3430c3b3ff8d10a2a86028c660355ab637cee9333d63d66b56f09d52a",
+                "sha256:0bf60faf0bc2468089bdc5edd10555bab6e85152191df713e2ab1fcc86382b5a",
+                "sha256:18a7f18b82b52ee85322d7a7874e676f34ab319b9f8cce5de06067384aa8ff43",
+                "sha256:18e98fb3de7dba1c0a852731c3070cf022d14f0d68b4c87a19cc1016f3bb8b33",
+                "sha256:1a819eef4b0e0b96bb0d98d797bef17dc1b4a10e8d7446be32d1da33e095dbb8",
+                "sha256:26fbfce90728d82bc9e6c38ea4d038cba20b7faf8a0ca53a9c07b67318d46088",
+                "sha256:2780572ec463d44c1d3ae850239508dbeb9fed38e294c68d19a24d925d9223ca",
+                "sha256:283737e0da3f08bd637b5ad058507e578dd462db259f7f6e4c5c365ba4ee9343",
+                "sha256:2d4686f195e32d36b4d7cf2d166857dbd0ee9f3d20ae349b6bf8afc8485b3645",
+                "sha256:2dd11f291565a81d71dab10b7033395b7a3a5456e637cf997a6f33ebdf06f8db",
+                "sha256:30bcf80dda7f15ac77ba5af2b961bdd9dbc77fd4ac6105cee85b0d0a5fcf74df",
+                "sha256:32e5b64b148966d9cccc2c8d35a671409e45f195864560829f395a54226408d3",
+                "sha256:36abbf031e1c0f79dd5d596bfaf8e921c41df2bdf54ee1eed921ce1f52999a86",
+                "sha256:3a06ad5312349fec0ab944664b01d26f8d1f05009566339ac6f63f56589bc1a2",
+                "sha256:3a51c9751078733d88e013587b108f1b7a1fb106d402fb390740f002b6f6551a",
+                "sha256:3c9b12575734155d0c09d6c3e10dbd81665d5c18e1a7c6597df72fd05990c8cf",
+                "sha256:3f6ea9bd35eb450837a3d80e77b517ea5bc56b4647f5502cd28de13675ee12f7",
+                "sha256:4b58adb399c4d61d912c4c331984d60eb66565175cdf4a34792cd9600f21b394",
+                "sha256:4d2e11331fc0c02b6e84b0d28ece3a36e0548ee1a1ce9ddde03752d9b79bba40",
+                "sha256:5454276c07d27a740c5892f4907c86327b632127dd9abec42ee62e12427ff7e3",
+                "sha256:561091a7be172ab497a3527602d467e2b3fbe75f9e783d8b8ce403fa414f71a6",
+                "sha256:6c3acb79b0bfd4fe733dff8bc62695283b57949ebcca05ae5c129eb606ff2d74",
+                "sha256:703f18f3fda276b9a916f0934d2fb6d989bf0b4fb5a64825260eb9bfd52d78f0",
+                "sha256:7492e2b7bd7c9b9916388d9df23fa49d9b88ac0640db0a5b4ecc2b653bf451e3",
+                "sha256:76ae285c8104046b3a7f06b42f29c7b73f77683df18c49ab5af7983994c2dd91",
+                "sha256:7cafd1208fdbe93b67c7086876f061f660cfddc44f404279c1585bbf3cdc64c5",
+                "sha256:7efde645ca1cc441d6dc4b48c0f7101e8d86b54c8530141b09fd31cef5149ec9",
+                "sha256:88d9ab96491d38a5ab7c56dd7a3cc37d83336ecc564e4e8816dbed12e5aaefc8",
+                "sha256:8eab883b3b2a38cc1e050819ef06a7e6344d4a990d24d45bc6f2cf959045a45b",
+                "sha256:910841381caba4f744a44bf81bfd573c94e10b3045ee00de0cbf436fe50673a6",
+                "sha256:9190f09060ea4debddd24665d6804b995a9c122ef5917ab26e1566dcc712ceeb",
+                "sha256:937e9020b514ceedb9c830c55d5c9872abc90f4b5862f89c0887033ae33c6f73",
+                "sha256:94c817e84245513926588caf1152e3b559ff794d505555211ca041f032abbb6b",
+                "sha256:971ce5e14dc5e73715755d0ca2975ac88cfdaefcaab078a284fea6cfabf866df",
+                "sha256:9d14b83fab60d5e8abe587d51c75b252bcc21683f24699ada8fb275d7712f5a9",
+                "sha256:9f35ec95538f50292f6d8f2c9c9f8a3c6540bbfec21c9e5b4b751e0a7c20864f",
+                "sha256:a1846f1b999e78e13837c93c778dcfc3365902cfb8d1bdb7dd73ead37059f0d0",
+                "sha256:acd2162a36d3de67ee896c43effcd5ee3de247eb00354db411feb025aa319857",
+                "sha256:b0ef99cdbe2b682b9ccbb964743a6aca37905fda5e0452e5ee239b1654d37f2a",
+                "sha256:b80f600eddddce72320dbbc8e3784d16bd3fb7b517e82476d8da921f27d4b249",
+                "sha256:b864ba53912b6c3ab6bcb2beb19f19edd01a6bfcbdfe1f37ddd1778abfe75a30",
+                "sha256:b9ec052b06a0524f0e35bd8790686a1da006bd911dd1ef7d50b77bfbad74e292",
+                "sha256:ba2956617f1c42598a308a84c6cf021a90ff3862eddafd20c3333d50f0edb45b",
+                "sha256:bdfea8c661e80d3c1c99ad7c3ff74e6e87184895bbaca6ee8cc61209f8b9b85d",
+                "sha256:be4ed120b52ae4d974aa40215fcdfde9194d63541c7ded40ee12eb4dda57b76b",
+                "sha256:c4302695ad8027363e96311df24ee28978162cdcdd2006476c43970b384a244c",
+                "sha256:c48f54ef8e05f04d6eff74b8233f6063cb1ed960243eacc474ee73a2ea8573ca",
+                "sha256:c9c59a2120b55788e800d82dfa99b9e156ff8f2227f07c5e3012a45a399620b7",
+                "sha256:cd021c754b162c0fb55ad5d6b9d960db667faad0fa2ff25bb6e1301b0b6e6a75",
+                "sha256:d27ec7509b9c18b6d73f2f5ede2622441de812e7b1a80bbd446cb0633bd3d5ae",
+                "sha256:d5508f0b173e6aa47273bdc0a0b5ba055b59662ba7c7ee5119528f466585526b",
+                "sha256:d75209eed723105f9596807495d58d10b3470fa6732dd6756595e89925ce2470",
+                "sha256:db1a39669102a1d8d12b57de2bb7e2ec9066a6f2b3da35ae511ff93b01b5d564",
+                "sha256:dbfcfc0218093a19c252ca8eb9aee3d29cfdcb586df21049b9d777fd32c14fd9",
+                "sha256:e0f72c9ddb8cd28532185f54cc1453f2c16fb417a08b53a855c4e6a418edd099",
+                "sha256:e7c8dc13af7db097bed64a051d2dd49e9f0af495c26995c00a9ee842690d34c0",
+                "sha256:ea9872c80c132f4663822dd2a08d404073a5a9b5ba6155bea72fb2a79d1093b5",
+                "sha256:eff4eb9b7eb3e4d0cae3d28c283dc16d9bed6b193c2e1ace3ed86ce48ea8df19",
+                "sha256:f82d4d717d8ef19188687aa32b8363e96062911e63ba22a0cff7802a8e58e5f1",
+                "sha256:fc3a569657468b6f3fb60587e48356fe512c1754ca05a564f11366ac9e306526"
+            ],
+            "markers": "platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))",
+            "version": "==2.0.2"
+        },
         "idna": {
             "hashes": [
                 "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
@@ -272,6 +338,25 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==0.1.2"
+        },
+        "psycopg2": {
+            "hashes": [
+                "sha256:093e3894d2d3c592ab0945d9eba9d139c139664dcf83a1c440b8a7aa9bb21955",
+                "sha256:190d51e8c1b25a47484e52a79638a8182451d6f6dff99f26ad9bd81e5359a0fa",
+                "sha256:1a5c7d7d577e0eabfcf15eb87d1e19314c8c4f0e722a301f98e0e3a65e238b4e",
+                "sha256:1e5a38aa85bd660c53947bd28aeaafb6a97d70423606f1ccb044a03a1203fe4a",
+                "sha256:322fd5fca0b1113677089d4ebd5222c964b1760e361f151cbb2706c4912112c5",
+                "sha256:4cb9936316d88bfab614666eb9e32995e794ed0f8f6b3b718666c22819c1d7ee",
+                "sha256:920bf418000dd17669d2904472efeab2b20546efd0548139618f8fa305d1d7ad",
+                "sha256:922cc5f0b98a5f2b1ff481f5551b95cd04580fd6f0c72d9b22e6c0145a4840e0",
+                "sha256:a5246d2e683a972e2187a8714b5c2cf8156c064629f9a9b1a873c1730d9e245a",
+                "sha256:b9ac1b0d8ecc49e05e4e182694f418d27f3aedcfca854ebd6c05bb1cffa10d6d",
+                "sha256:d3ef67e630b0de0779c42912fe2cbae3805ebaba30cda27fea2a3de650a9414f",
+                "sha256:f5b6320dbc3cf6cfb9f25308286f9f7ab464e65cfb105b64cc9c52831748ced2",
+                "sha256:fc04dd5189b90d825509caa510f20d1d504761e78b8dfb95a0ede180f71d50e5"
+            ],
+            "index": "pypi",
+            "version": "==2.9.5"
         },
         "pycparser": {
             "hashes": [
@@ -344,8 +429,55 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
+        },
+        "sqlalchemy": {
+            "hashes": [
+                "sha256:01704ec4a6877b74608264992a87979a27a8927cefd14ccdc0d478acacc1ed85",
+                "sha256:0186b970fd4561def531b582a86819d8f8af65c8b1a78cf015ee47e526f4cfb6",
+                "sha256:05b81afdc25d1ce43cb59647c9992559dc7487b1670ccab0426fc8b8f859e933",
+                "sha256:08c9169692722df8a2ef6c6ff1055e11563c990e9c74df9af62139a0c6397b8c",
+                "sha256:0fcc9b2f5b334fdaf278459dfc0fb86d3a0317ae8ce813a7a3ef8639b44b6e4a",
+                "sha256:101df3fa8f207ade1124d7729f6c9eab28a2560baa31b3e131e76a599d884b33",
+                "sha256:1f504779e6e68d0cb7043825958125abd7742c7c73ce9c6b652d20c6b5f17022",
+                "sha256:20b9e36f0219285c580dc5e98cadb59b751e259f3829460bc58d45e7a770dd36",
+                "sha256:31d019c60f4817b24c484d3110c7754cd2b8f7070057eddef5822994bf16da5a",
+                "sha256:34a4e134eac68354cce40b35ccdbc91ff67ce0c791ea4aa81e021f2ee14bfefb",
+                "sha256:3846d36c1ca113a7fa078abb5e69a8c3d1c7642baf12267dcd9a0d660cf1bdeb",
+                "sha256:3997238968fa495fac4b17fa18b36616c41a6e6759f323dfb3f83cbcf1d3b1bb",
+                "sha256:476bd377f430b1871f058332696ef61c42dfa8ad242ebb8bcf212c3d4127ea8a",
+                "sha256:54b24a20cca275ada37ba40aa87dd257fda6e7da7f448d3282b6124d940f64d5",
+                "sha256:5bc451ee18776dcb6b2ac8c154db0536f75a2535f5da055179734f5e7f2e7b72",
+                "sha256:619784c399f5c4240b002e4dba30cfba15696274614da77846b69b2c9a74066b",
+                "sha256:655e93fabd11bf53e6af44cee152b608d49ece4b4d9cc29328dd476faaa47c0c",
+                "sha256:664a21613d7eff895de9ef731632575cfca773ddbac9b7f7adad288ab971bcbd",
+                "sha256:664ec164bc01ab66dfd19062ca7982a9ea12274596e17732908eb78621adc147",
+                "sha256:67c35b33a0828b4f5ac6e76a1b6a54b27d693599c93ea7a4c8e53ff52796378f",
+                "sha256:6dd8405bd1ffcbf11fda0e6b172e7e90044610de16325295efe92367551f666d",
+                "sha256:70d38432d75f6c95973f9713b30881e40a4e8d8ccfe8bbeb55466d8c737acc79",
+                "sha256:7b07b83789997cf83ce9a5e7156a2b9a6cb54a4137add8ad95eff32f6746279b",
+                "sha256:7e23205506a437476dce8193357ce47254cce7c94018b1b4856476ad2e74f1ae",
+                "sha256:8770318683c8e08976633cec2c9711eb4279553ecbad1ca97f82c5b9174e0e76",
+                "sha256:8f9085bedb9e2f2bf714cfd86be6deaa7050f998843a3a0e595ec3eb0d25c743",
+                "sha256:9efb27e899cf7d43cf42c0852ef772a8b568c39dc7b55768a5a80c67bb64dfc2",
+                "sha256:a5e1826a1ebbbbc26285a0304d7cafff4ec63cdae83fde89d5f2ec67f4444a44",
+                "sha256:a97c4b5527ea563867ccbee031af93932d9699c6c73f1ea70adcbc935c80379e",
+                "sha256:aeb49e1436d6558d31c006b385a5071e802be6db257ce36940e66cefce92aa72",
+                "sha256:c34c6b7975cb9e4848d4366d54a634bbced7b491a36029642c7e738a44b595a3",
+                "sha256:c681d0f59c8ed12fd3f68d08d423354b1cc501220ddabc7a20b9ca8ed52b8f70",
+                "sha256:ca2ce5f3125cb6e043c90dd901446b74878f35eb6660e0e58d7ef02832f7d332",
+                "sha256:d1588f6ba25dbb2d6eb1531e56f419e02cdc9ec06d9f082195877c5148f6f6ab",
+                "sha256:db3e4db26c1a771d7b23a1031eaf351cfcaaa96d463ae900bb56c6a6f0585fbf",
+                "sha256:e49e9aefffe9c598a6ccf8d2dbb4556f4d93d0ae346b9d199b3712d24af0ce75",
+                "sha256:e60bec8fdd753212aa8cec012bbb3060e9c2227496fa935ca8918744a34c864d",
+                "sha256:eeec87ebe90018bc871b84b03e4bff5dbdc722e28b8f5a6e9a94486eb0cb4902",
+                "sha256:eff376cc201363634b5b60a828b3998b088a71e16f7a43da26fc0e2201e25a05",
+                "sha256:f44c37e03cb941dd0db371a9f391cfb586c9966f436bf18b5492ee26f5ac6a5b",
+                "sha256:f707729cc35dbd1d672b11037f5464b8a42c1e89772d7fc60648da215fa72fc6"
+            ],
+            "index": "pypi",
+            "version": "==2.0.1"
         },
         "tuf": {
             "hashes": [
@@ -354,6 +486,14 @@
             ],
             "index": "pypi",
             "version": "==2.0.0"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa",
+                "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==4.4.0"
         },
         "urllib3": {
             "hashes": [
@@ -399,21 +539,34 @@
         },
         "black": {
             "hashes": [
-                "sha256:101c69b23df9b44247bd88e1d7e90154336ac4992502d4197bdac35dd7ee3320",
-                "sha256:159a46a4947f73387b4d83e87ea006dbb2337eab6c879620a3ba52699b1f4351",
-                "sha256:1f58cbe16dfe8c12b7434e50ff889fa479072096d79f0a7f25e4ab8e94cd8350",
-                "sha256:229351e5a18ca30f447bf724d007f890f97e13af070bb6ad4c0a441cd7596a2f",
-                "sha256:436cc9167dd28040ad90d3b404aec22cedf24a6e4d7de221bec2730ec0c97bcf",
-                "sha256:559c7a1ba9a006226f09e4916060982fd27334ae1998e7a38b3f33a37f7a2148",
-                "sha256:7412e75863aa5c5411886804678b7d083c7c28421210180d67dfd8cf1221e1f4",
-                "sha256:77d86c9f3db9b1bf6761244bc0b3572a546f5fe37917a044e02f3166d5aafa7d",
-                "sha256:82d9fe8fee3401e02e79767016b4907820a7dc28d70d137eb397b92ef3cc5bfc",
-                "sha256:9eedd20838bd5d75b80c9f5487dbcb06836a43833a37846cf1d8c1cc01cef59d",
-                "sha256:c116eed0efb9ff870ded8b62fe9f28dd61ef6e9ddd28d83d7d264a38417dcee2",
-                "sha256:d30b212bffeb1e252b31dd269dfae69dd17e06d92b87ad26e23890f3efea366f"
+                "sha256:0052dba51dec07ed029ed61b18183942043e00008ec65d5028814afaab9a22fd",
+                "sha256:0680d4380db3719ebcfb2613f34e86c8e6d15ffeabcf8ec59355c5e7b85bb555",
+                "sha256:121ca7f10b4a01fd99951234abdbd97728e1240be89fde18480ffac16503d481",
+                "sha256:162e37d49e93bd6eb6f1afc3e17a3d23a823042530c37c3c42eeeaf026f38468",
+                "sha256:2a951cc83ab535d248c89f300eccbd625e80ab880fbcfb5ac8afb5f01a258ac9",
+                "sha256:2bf649fda611c8550ca9d7592b69f0637218c2369b7744694c5e4902873b2f3a",
+                "sha256:382998821f58e5c8238d3166c492139573325287820963d2f7de4d518bd76958",
+                "sha256:49f7b39e30f326a34b5c9a4213213a6b221d7ae9d58ec70df1c4a307cf2a1580",
+                "sha256:57c18c5165c1dbe291d5306e53fb3988122890e57bd9b3dcb75f967f13411a26",
+                "sha256:7a0f701d314cfa0896b9001df70a530eb2472babb76086344e688829efd97d32",
+                "sha256:8178318cb74f98bc571eef19068f6ab5613b3e59d4f47771582f04e175570ed8",
+                "sha256:8b70eb40a78dfac24842458476135f9b99ab952dd3f2dab738c1881a9b38b753",
+                "sha256:9880d7d419bb7e709b37e28deb5e68a49227713b623c72b2b931028ea65f619b",
+                "sha256:9afd3f493666a0cd8f8df9a0200c6359ac53940cbde049dcb1a7eb6ee2dd7074",
+                "sha256:a29650759a6a0944e7cca036674655c2f0f63806ddecc45ed40b7b8aa314b651",
+                "sha256:a436e7881d33acaf2536c46a454bb964a50eff59b21b51c6ccf5a40601fbef24",
+                "sha256:a59db0a2094d2259c554676403fa2fac3473ccf1354c1c63eccf7ae65aac8ab6",
+                "sha256:a8471939da5e824b891b25751955be52ee7f8a30a916d570a5ba8e0f2eb2ecad",
+                "sha256:b0bd97bea8903f5a2ba7219257a44e3f1f9d00073d6cc1add68f0beec69692ac",
+                "sha256:b6a92a41ee34b883b359998f0c8e6eb8e99803aa8bf3123bf2b2e6fec505a221",
+                "sha256:bb460c8561c8c1bec7824ecbc3ce085eb50005883a6203dcfb0122e95797ee06",
+                "sha256:bfffba28dc52a58f04492181392ee380e95262af14ee01d4bc7bb1b1c6ca8d27",
+                "sha256:c1c476bc7b7d021321e7d93dc2cbd78ce103b84d5a4cf97ed535fbc0d6660648",
+                "sha256:c91dfc2c2a4e50df0026f88d2215e166616e0c80e86004d0003ece0488db2739",
+                "sha256:e6663f91b6feca5d06f2ccd49a10f254f9298cc1f7f49c46e498a0771b507104"
             ],
             "index": "pypi",
-            "version": "==22.12.0"
+            "version": "==23.1.0"
         },
         "build": {
             "hashes": [
@@ -641,7 +794,7 @@
                 "sha256:167524e377358ed1f1374e61c268f0d7a4bf7dbd046c656f7b410cde16161b1a",
                 "sha256:ee686a8db9f5d91da39849f175ffeef094dd0e9c36d6a59a2e8c7f92a3b80020"
             ],
-            "markers": "python_version > '3'",
+            "markers": "python_version >= '3.1'",
             "version": "==0.3"
         },
         "exceptiongroup": {
@@ -842,10 +995,11 @@
         },
         "mypy-extensions": {
             "hashes": [
-                "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
-                "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
+                "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d",
+                "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"
             ],
-            "version": "==0.4.3"
+            "markers": "python_version >= '3.5'",
+            "version": "==1.0.0"
         },
         "nodeenv": {
             "hashes": [
@@ -860,7 +1014,7 @@
                 "sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2",
                 "sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"
             ],
-            "markers": "python_version > '3'",
+            "markers": "python_version >= '3.1'",
             "version": "==23.0"
         },
         "pathspec": {
@@ -881,11 +1035,11 @@
         },
         "pip": {
             "hashes": [
-                "sha256:65fd48317359f3af8e593943e6ae1506b66325085ea64b706a998c6e83eeaf38",
-                "sha256:908c78e6bc29b676ede1c4d57981d490cb892eb45cd8c214ab6298125119e077"
+                "sha256:aee438284e82c8def684b0bcc50b1f6ed5e941af97fa940e83e2e8ef1a59da9b",
+                "sha256:b5f88adff801f5ef052bcdef3daa31b55eb67b0fccd6d0106c206fa248e0463c"
             ],
             "index": "pypi",
-            "version": "==22.3.1"
+            "version": "==23.0"
         },
         "platformdirs": {
             "hashes": [
@@ -900,16 +1054,16 @@
                 "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
                 "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
             ],
-            "markers": "python_version > '3'",
+            "markers": "python_version >= '3.1'",
             "version": "==1.0.0"
         },
         "pre-commit": {
             "hashes": [
-                "sha256:aa97fa71e7ab48225538e1e91a6b26e483029e6de64824f04760c32557bc91d7",
-                "sha256:f448d5224c70e196a6c6f87961d2333dfdc49988ebbf660477f9efe991c03597"
+                "sha256:9e3255edb0c9e7fe9b4f328cb3dc86069f8fdc38026f1bf521018a05eaf4d67b",
+                "sha256:bc4687478d55578c4ac37272fe96df66f73d9b5cf81be6f28627d4e712e752d5"
             ],
             "index": "pypi",
-            "version": "==3.0.2"
+            "version": "==3.0.4"
         },
         "pretend": {
             "hashes": [
@@ -1030,11 +1184,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:883131c5b6efa70b9101c7ef30b2b7b780a4283d5fc1616383cdf22c83cbefe6",
-                "sha256:9d790961ba6219e9ff7d9557622d2fe136816a264dd01d5997cfc057d804853d"
+                "sha256:a7687c12b444eaac951ea87a9627c4f904ac757e7abdc5aac32833234af90378",
+                "sha256:e261cdf010c11a41cb5cb5f1bf3338a7433832029f559a6a7614bd42a967c300"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==67.0.0"
+            "version": "==67.1.0"
         },
         "smmap": {
             "hashes": [
@@ -1085,11 +1239,11 @@
         },
         "sphinxcontrib-htmlhelp": {
             "hashes": [
-                "sha256:d412243dfb797ae3ec2b59eca0e52dac12e75a241bf0e4eb861e450d06c6ed07",
-                "sha256:f5f8bb2d0d629f398bf47d0d69c07bc13b65f75a81ad9e2f71a63d4b7a2f6db2"
+                "sha256:0cbdd302815330058422b98a113195c9249825d681e18f11e8b1f78a2f11efff",
+                "sha256:c38cb46dccf316c79de6e5515e1770414b797162b23cd3d06e67020e1d2a6903"
             ],
             "index": "pypi",
-            "version": "==2.0.0"
+            "version": "==2.0.1"
         },
         "sphinxcontrib-jsmath": {
             "hashes": [
@@ -1127,7 +1281,7 @@
                 "sha256:7f8aeb6e3f90f96832c301bff21a7eb5eefbe894c88c506483d355565d88cc1a",
                 "sha256:aa6436565c069b2946fe4ebff07f5041e0c8bf18c7376dd29edf80cf7d524e4e"
             ],
-            "markers": "python_full_version >= '3.8.0'",
+            "markers": "python_version >= '3.8'",
             "version": "==4.1.1"
         },
         "tomli": {
@@ -1135,16 +1289,16 @@
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
                 "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_version > '3'",
+            "markers": "python_version >= '3.1'",
             "version": "==2.0.1"
         },
         "tox": {
             "hashes": [
-                "sha256:258895ba5de919490c03ef97467c4c8c42954537dfd96ae72cc2fb63dac67cf0",
-                "sha256:3d8a8dd8a5afdc0d37af3e2b4959e427fe22530d0aa599baf0120e144b3defa3"
+                "sha256:1195820ca35b141ce5ab040c9dfad8f03de6897c9bd867c6151dfb7dc58e64cd",
+                "sha256:e1ef01d9e9503b1218511f74517dc3f0008c8b5e0cc53ab7f51ff3c2ca63b349"
             ],
             "index": "pypi",
-            "version": "==4.4.2"
+            "version": "==4.4.4"
         },
         "types-requests": {
             "hashes": [
@@ -1179,11 +1333,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:ce3b1684d6e1a20a3e5ed36795a97dfc6af29bc3970ca8dab93e11ac6094b3c4",
-                "sha256:f8b927684efc6f1cc206c9db297a570ab9ad0e51c16fa9e45487d36d1905c058"
+                "sha256:9d61e4ec8d2c0345dab329fb825eb05579043766a4b26a2f66b28948de68c722",
+                "sha256:f262457a4d7298a6b733b920a196bf8b46c8af15bf1fd9da7142995eff15118e"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==20.17.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==20.18.0"
         }
     }
 }

--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -456,7 +456,7 @@ Import Targets (``import-targets``)
 
 This feature imports a large number of targets directly to RSTUF Database.
 RSTUF doesn't recommend using this feature for regular flow, but in case you're
-onboarding an existent repository that contains a larget number of targets.
+onboarding an existent repository that contains a large number of targets.
 
 This feature requires extra dependencies:
 
@@ -464,7 +464,7 @@ This feature requires extra dependencies:
 
     pip install repository-service-tuf[psycopg2,sqlachemy]
 
-To use this feature, you need create CSV files with the content to be imported
+To use this feature, you need to create CSV files with the content to be imported
 by RSTUF CLI.
 
 This content requires the following data:

--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -449,3 +449,77 @@ Show token detailed information.
     },
     "message": "Token information"
     }
+
+
+Import Targets (``import-targets``)
+-----------------------------------
+
+This feature imports a large number of targets directly to RSTUF Database.
+RSTUF doesn't recommend using this feature for regular flow, but in case you're
+onboarding an existent repository that contains a larget number of targets.
+
+This feature requires extra dependencies:
+
+.. code:: shell
+
+    pip install repository-service-tuf[psycopg2,sqlachemy]
+
+To use this feature, you need create CSV files with the content to be imported
+by RSTUF CLI.
+
+This content requires the following data:
+
+- `path <https://theupdateframework.github.io/specification/latest/#targetpath>`_: The target path
+- `size <https://theupdateframework.github.io/specification/latest/#targets-obj-length>`_: The target size
+- `hash-type <https://theupdateframework.github.io/specification/latest/#targets-obj-length>`_: The defined hash as a metafile. Example: blak2b-256
+- `hash <https://theupdateframework.github.io/specification/latest/#targets-obj-length>`_: The hash
+
+The CSV must use a semicolon as the separator, following the format
+``path;size;hash-type;hash`` without a header.
+
+See the below CSV file example:
+
+.. code::
+
+    relaxed_germainv1.tar.gz;12345;blake2b-256;716f6e863f744b9ac22c97ec7b76ea5f5908bc5b2f67c61510bfc4751384ea7a
+    vigilant_keldyshv2.tar.gz;12345;blake2b-256;716f6e863f744b9ac22c97ec7b76ea5f5908bc5b2f67c61510bfc4751384ea7a
+    adoring_teslav3.tar.gz;12345;blake2b-256;716f6e863f744b9ac22c97ec7b76ea5f5908bc5b2f67c61510bfc4751384ea7a
+    funny_greiderv4.tar.gz;12345;blake2b-256;716f6e863f744b9ac22c97ec7b76ea5f5908bc5b2f67c61510bfc4751384ea7a
+    clever_ardinghelliv5.tar.gz;12345;blake2b-256;716f6e863f744b9ac22c97ec7b76ea5f5908bc5b2f67c61510bfc4751384ea7a
+    pbeat_galileov6.tar.gz;12345;blake2b-256;716f6e863f744b9ac22c97ec7b76ea5f5908bc5b2f67c61510bfc4751384ea7a
+    wonderful_gangulyv7.tar.gz;12345;blake2b-256;716f6e863f744b9ac22c97ec7b76ea5f5908bc5b2f67c61510bfc4751384ea7a
+    sweet_ardinghelliv8.tar.gz;12345;blake2b-256;716f6e863f744b9ac22c97ec7b76ea5f5908bc5b2f67c61510bfc4751384ea7a
+    brave_mendelv9.tar.gz;12345;blake2b-256;716f6e863f744b9ac22c97ec7b76ea5f5908bc5b2f67c61510bfc4751384ea7a
+    nice_ridev10.tar.gz;12345;blake2b-256;716f6e863f744b9ac22c97ec7b76ea5f5908bc5b2f67c61510bfc4751384ea7a
+
+
+.. code:: shell
+
+    ❯ rstuf admin import-targets -h
+
+     Usage: rstuf admin import-targets [OPTIONS]
+
+     Import targets to RSTUF from exported CSV file.
+
+    ╭─ Options ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+    │ *                          -metadata-url  TEXT  RSTUF Metadata URL i.e.: http://127.0.0.1 . [required]                                                          │
+    │ *                          -db-uri        TEXT  RSTUF DB URI. i.e.: postgresql://postgres:secret@127.0.0.1:5433 [required]                                      │
+    │ *                          -csv           TEXT  CSV file to import. Multiple -csv parameters are allowed. See rstuf CLI guide for more details. [required]      │
+    │    --skip-publish-targets                       Skip publishing targets in TUF Metadata.                                                                        │
+    │    --help                  -h                   Show this message and exit.                                                                                     │
+    ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+    ❯ rstuf admin import-targets -db-uri postgresql://postgres:secret@127.0.0.1:5433 -csv targets-1of2.csv -csv targets-2of2.csv -metadata-url http://127.0.0.1:8080/
+    Import status: Loading data from ../repository-service-tuf/tests/data/targets-1of2.csv
+    Import status: Importing ../repository-service-tuf/tests/data/targets-1of2.csv data
+    Import status: ../repository-service-tuf/tests/data/targets-1of2.csv imported
+    Import status: Loading data from ../repository-service-tuf/tests/data/targets-2of2.csv
+    Import status: Importing ../repository-service-tuf/tests/data/targets-2of2.csv data
+    Import status: ../repository-service-tuf/tests/data/targets-2of2.csv imported
+    Import status: Commiting all data to the RSTUF database
+    Import status: All data imported to RSTUF DB
+    Import status: Submitting action publish targets
+    Import status: Publish targets task id is dd1cbf2320ad4df6bda9ca62cdc0ef82
+    Import status: task STARTED
+    Import status: task SUCCESS
+    Import status: Finished.

--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -502,14 +502,14 @@ See the below CSV file example:
      Import targets to RSTUF from exported CSV file.
 
     ╭─ Options ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-    │ *                          -metadata-url  TEXT  RSTUF Metadata URL i.e.: http://127.0.0.1 . [required]                                                          │
-    │ *                          -db-uri        TEXT  RSTUF DB URI. i.e.: postgresql://postgres:secret@127.0.0.1:5433 [required]                                      │
-    │ *                          -csv           TEXT  CSV file to import. Multiple -csv parameters are allowed. See rstuf CLI guide for more details. [required]      │
+    │ *                          --metadata-url  TEXT  RSTUF Metadata URL i.e.: http://127.0.0.1 . [required]                                                         │
+    │ *                          --db-uri        TEXT  RSTUF DB URI. i.e.: postgresql://postgres:secret@127.0.0.1:5433 [required]                                     │
+    │ *                          --csv           TEXT  CSV file to import. Multiple --csv parameters are allowed. See rstuf CLI guide for more details. [required]    │
     │    --skip-publish-targets                       Skip publishing targets in TUF Metadata.                                                                        │
     │    --help                  -h                   Show this message and exit.                                                                                     │
     ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 
-    ❯ rstuf admin import-targets -db-uri postgresql://postgres:secret@127.0.0.1:5433 -csv targets-1of2.csv -csv targets-2of2.csv -metadata-url http://127.0.0.1:8080/
+    ❯ rstuf admin import-targets --db-uri postgresql://postgres:secret@127.0.0.1:5433 --csv targets-1of2.csv --csv targets-2of2.csv --metadata-url http://127.0.0.1:8080/
     Import status: Loading data from ../repository-service-tuf/tests/data/targets-1of2.csv
     Import status: Importing ../repository-service-tuf/tests/data/targets-1of2.csv data
     Import status: ../repository-service-tuf/tests/data/targets-1of2.csv imported

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,5 +46,9 @@ ignore_missing_imports = true
 [tool.hatch.version]
 path = "repository_service_tuf/__version__.py"
 
+[project.optional-dependencies]
+psycopg2 = ["psycopg2>=2.9.5"]  # required by import-targets sub-command
+sqlalchemy = ["sqlalchemy>=2.0.1"]  # required by import-targets sub-command
+
 [project.scripts]
 rstuf = "repository_service_tuf.cli:rstuf"

--- a/repository_service_tuf/cli/admin/ceremony.py
+++ b/repository_service_tuf/cli/admin/ceremony.py
@@ -520,16 +520,16 @@ def ceremony(context, bootstrap, file, upload, save) -> None:
         bs_response = request_server(
             settings.SERVER, URL.bootstrap.value, Methods.get, headers=headers
         )
-        bs_data = bs_response.json()
         if bs_response.status_code == 404:
             raise click.ClickException(
                 f"Server {settings.SERVER} doesn't allow bootstrap"
             )
         if bs_response.status_code != 200:
             raise click.ClickException(
-                f"Error {bs_response.status_code} {bs_data.get('detail')}"
+                f"Error {bs_response.status_code} {bs_response.text}"
             )
 
+        bs_data = bs_response.json()
         if bs_data.get("bootstrap") is True or None:
             raise click.ClickException(f"{bs_data.get('message')}")
 

--- a/repository_service_tuf/cli/admin/ceremony.py
+++ b/repository_service_tuf/cli/admin/ceremony.py
@@ -7,7 +7,6 @@
 #
 import json
 import os
-import time
 from dataclasses import asdict, dataclass
 from enum import Enum
 from typing import Any, Dict, Optional
@@ -29,8 +28,9 @@ from repository_service_tuf.cli.admin import admin
 from repository_service_tuf.helpers.api_client import (
     URL,
     Methods,
-    is_logged,
+    get_headers,
     request_server,
+    task_status,
 )
 from repository_service_tuf.helpers.tuf import (
     RolesKeysInput,
@@ -426,37 +426,6 @@ def _configure_keys(rolename: str, role: RolesKeysInput) -> None:
         key_count += 1
 
 
-def _check_server(settings) -> dict[str, str]:
-    server = settings.get("SERVER")
-    token = settings.get("TOKEN")
-    if server and token:
-        token_access_check = is_logged(server, token)
-        if token_access_check.state is False:
-            raise click.ClickException(
-                f"{str(token_access_check.data)}"
-                "\n\nTry re-login: 'Repository Service for TUF admin login'"
-            )
-
-        expired_admin = token_access_check.data.get("expired")
-        if expired_admin is True:
-            raise click.ClickException(
-                "Token expired. Run 'Repository Service for TUF admin login'"
-            )
-        else:
-            headers = {"Authorization": f"Bearer {token}"}
-            response = request_server(
-                server, URL.bootstrap.value, Methods.get, headers=headers
-            )
-            if response.status_code != 200 and (
-                response.json().get("bootstrap") is True or None
-            ):
-                raise click.ClickException(f"{response.json().get('detail')}")
-    else:
-        raise click.ClickException("Login first. Run 'rstuf-cli admin login'")
-
-    return headers
-
-
 def _bootstrap(server, headers, json_payload) -> Optional[str]:
     task_id = None
     response = request_server(
@@ -484,58 +453,6 @@ def _bootstrap(server, headers, json_payload) -> Optional[str]:
             console.print(f"Bootstrap status: ACCEPTED ({task_id})")
 
     return task_id
-
-
-def _bootstrap_state(task_id, server, headers) -> None:
-    received_state = []
-    while True:
-        state_response = request_server(
-            server, f"{URL.task.value}{task_id}", Methods.get, headers=headers
-        )
-
-        if state_response.status_code != 200:
-            raise click.ClickException(
-                f"Unexpected response {state_response.text}"
-            )
-
-        data = state_response.json().get("data")
-
-        if data:
-            if state := data.get("state"):
-                if state not in received_state:
-                    console.print(f"Bootstrap status: {state}")
-                    received_state.append(state)
-
-                if state == "SUCCESS":
-                    try:
-                        result = data.get("result")
-                        bootstrap_result = result.get("details").get(
-                            "bootstrap"
-                        )
-                    except AttributeError:
-                        bootstrap_result = False
-
-                    if bootstrap_result is not True:
-                        raise click.ClickException(
-                            f"Something went wrong, result: {result}"
-                        )
-
-                    console.print("[green]Bootstrap finished.[/]")
-                    break
-
-                elif state == "FAILURE":
-                    raise click.ClickException(
-                        f"Failed: {state_response.text}"
-                    )
-            else:
-                raise click.ClickException(
-                    f"No state in data received {state_response.text}"
-                )
-        else:
-            raise click.ClickException(
-                f"No data received {state_response.text}"
-            )
-        time.sleep(2)
 
 
 @admin.command()
@@ -599,7 +516,7 @@ def ceremony(context, bootstrap, file, upload, save) -> None:
 
     settings = context.obj["settings"]
     if bootstrap:
-        headers = _check_server(settings)
+        headers = get_headers(settings)
         bs_response = request_server(
             settings.SERVER, URL.bootstrap.value, Methods.get, headers=headers
         )
@@ -775,6 +692,6 @@ def ceremony(context, bootstrap, file, upload, save) -> None:
         if task_id is None:
             raise click.ClickException("task id wasn't received")
 
-        _bootstrap_state(task_id, settings.SERVER, headers)
+        task_status(task_id, settings.SERVER, headers, "Bootstrap status: ")
 
     console.print("\nCeremony done. 🔐 🎉")

--- a/repository_service_tuf/cli/admin/import_targets.py
+++ b/repository_service_tuf/cli/admin/import_targets.py
@@ -106,7 +106,13 @@ def _import_csv_to_rstuf(
     help="Skip publishing targets in TUF Metadata.",
 )
 @click.pass_context
-def import_targets(context, metadata_url, db_uri, csv, skip_publish_targets):
+def import_targets(
+    context,
+    metadata_url: str,
+    db_uri: str,
+    csv: List[str],
+    skip_publish_targets: bool,
+):
     """
     Import targets to RSTUF from exported CSV file.
     """
@@ -139,7 +145,7 @@ def import_targets(context, metadata_url, db_uri, csv, skip_publish_targets):
     rstuf_table = Table("rstuf_targets", db_metadata, autoload_with=engine)
 
     # validate if the CSV files are accessible
-    _check_csv_files(csv)
+    _check_csv_files(csv_files=csv)
     # import all CSV file(s) data to RSTUF DB without commiting
     _import_csv_to_rstuf(db_client, rstuf_table, csv, succinct_roles)
 

--- a/repository_service_tuf/cli/admin/import_targets.py
+++ b/repository_service_tuf/cli/admin/import_targets.py
@@ -100,7 +100,7 @@ def _import_csv_to_rstuf(
 @click.option(
     "--skip-publish-targets",
     is_flag=True,
-    help="Skip publish targets process in TUF Metadata.",
+    help="Skip publishing targets in TUF Metadata.",
 )
 @click.pass_context
 def import_targets(context, metadata_url, db_uri, csv, skip_publish_targets):

--- a/repository_service_tuf/cli/admin/import_targets.py
+++ b/repository_service_tuf/cli/admin/import_targets.py
@@ -13,7 +13,6 @@ from repository_service_tuf.helpers.api_client import (
     URL,
     Methods,
     get_headers,
-    is_logged,
     publish_targets,
     request_server,
     task_status,
@@ -106,17 +105,17 @@ def _get_succinct_roles(metadata_url: str) -> SuccinctRoles:
 
 @admin.command()
 @click.option(
-    "-metadata-url",
+    "--metadata-url",
     required=True,
     help="RSTUF Metadata URL i.e.: http://127.0.0.1 .",
 )
 @click.option(
-    "-db-uri",
+    "--db-uri",
     required=True,
     help="RSTUF DB URI. i.e.: postgresql://postgres:secret@127.0.0.1:5433",
 )
 @click.option(
-    "-csv",
+    "--csv",
     required=True,
     multiple=True,
     help=(
@@ -142,16 +141,6 @@ def import_targets(
     """
     settings = context.obj["settings"]
     server = settings.get("SERVER")
-    token = settings.get("TOKEN")
-    if server and token:
-        token_access_check = is_logged(server, token)
-        if token_access_check.state is False:
-            raise click.ClickException(
-                f"{str(token_access_check.data)}"
-                "\n\nTry re-login: 'Repository Service for TUF admin login'"
-            )
-    else:
-        raise click.ClickException("Login first. Run 'rstuf admin login'")
 
     headers = get_headers(settings)
 

--- a/repository_service_tuf/cli/admin/import_targets.py
+++ b/repository_service_tuf/cli/admin/import_targets.py
@@ -95,7 +95,10 @@ def _import_csv_to_rstuf(
     "-csv",
     required=True,
     multiple=True,
-    help="CSV file to import. Multiple -csv parameters are allowed.",
+    help=(
+        "CSV file to import. Multiple -csv parameters are allowed. "
+        "See rstuf CLI guide for more details."
+    ),
 )
 @click.option(
     "--skip-publish-targets",

--- a/repository_service_tuf/cli/admin/import_targets.py
+++ b/repository_service_tuf/cli/admin/import_targets.py
@@ -1,0 +1,168 @@
+import json
+import os
+from datetime import datetime
+from typing import Any, Dict, List
+
+from rich.console import Console
+from sqlalchemy import Connection, MetaData, Table, create_engine
+from sqlalchemy.exc import IntegrityError
+
+from repository_service_tuf.cli import click
+from repository_service_tuf.cli.admin import admin
+from repository_service_tuf.helpers.api_client import (
+    URL,
+    Methods,
+    get_headers,
+    is_logged,
+    request_server,
+    task_status,
+)
+from repository_service_tuf.helpers.tuf import Metadata, SuccinctRoles
+
+console = Console()
+
+
+def _check_csv_files(csv_files: List[str]):
+    not_found_csv_files: List[str] = []
+    for csv_file in csv_files:
+        if not os.path.isfile(csv_file):
+            not_found_csv_files.append(csv_file)
+
+    if len(not_found_csv_files) > 0:
+        raise click.ClickException(
+            f"CSV file(s) not found: {(', ').join(not_found_csv_files)}"
+        )
+
+
+def _parse_csv_data(
+    csv_file: str, succinct_roles: SuccinctRoles
+) -> List[Dict[str, Any]]:
+    rstuf_db_data: List[Dict[str, Any]] = []
+    with open(csv_file, "r") as f:
+        for line in f:
+            rstuf_db_data.append(
+                {
+                    "path": line.split(";")[0],
+                    "info": {
+                        "length": int(line.split(";")[1]),
+                        "hashes": {line.split(";")[2]: line.split(";")[3]},
+                    },
+                    "rolename": succinct_roles.get_role_for_target(
+                        line.split(";")[0]
+                    ),
+                    "published": False,
+                    "action": "ADD",
+                    "last_update": datetime.now(),
+                }
+            )
+
+    return rstuf_db_data
+
+
+def _import_csv_to_rstuf(
+    db_client: Connection,
+    rstuf_table: Table,
+    csv_files: List[str],
+    succinct_roles: SuccinctRoles,
+) -> None:
+    for csv_file in csv_files:
+        console.print(f"Import status: Loading data from {csv_file}")
+        rstuf_db_data = _parse_csv_data(csv_file, succinct_roles)
+        console.print(f"Import status: Importing {csv_file} data")
+        try:
+            db_client.execute(rstuf_table.insert(), rstuf_db_data)
+        except IntegrityError:
+            raise click.ClickException(
+                "Import status: ABORTED due duplicated targets. "
+                "CSV files must to have unique targets (path). "
+                "No data added to RSTUF DB."
+            )
+        console.print(f"Import status: {csv_file} imported")
+
+
+@admin.command()
+@click.option(
+    "-metadata-url",
+    required=True,
+    help="RSTUF Metadata URL i.e.: http://127.0.0.1 .",
+)
+@click.option(
+    "-db-uri",
+    required=True,
+    help="RSTUF DB URI. i.e.: postgresql://postgres:secret@127.0.0.1:5433",
+)
+@click.option(
+    "-csv",
+    required=True,
+    multiple=True,
+    help="CSV file to import. Multiple -csv parameters are allowed.",
+)
+@click.option(
+    "--skip-publish-targets",
+    is_flag=True,
+    help="Skip publish targets process in TUF Metadata.",
+)
+@click.pass_context
+def import_targets(context, metadata_url, db_uri, csv, skip_publish_targets):
+    """
+    Import targets to RSTUF from exported CSV file.
+    """
+    settings = context.obj["settings"]
+    server = settings.get("SERVER")
+    token = settings.get("TOKEN")
+    if server and token:
+        token_access_check = is_logged(server, token)
+        if token_access_check.state is False:
+            raise click.ClickException(
+                f"{str(token_access_check.data)}"
+                "\n\nTry re-login: 'Repository Service for TUF admin login'"
+            )
+    else:
+        raise click.ClickException("Login first. Run 'rstuf admin login'")
+
+    headers = get_headers(settings)
+
+    response = request_server(metadata_url, "1.bin.json", Methods.get)
+    if response.status_code == 404:
+        raise click.ClickException("RSTUF Metadata Targets not found.")
+
+    # load all required infrastructure
+    json_data = json.loads(response.text)
+    targets = Metadata.from_dict(json_data)
+    succinct_roles = targets.signed.delegations.succinct_roles
+    engine = create_engine(f"{db_uri}")
+    db_metadata = MetaData()
+    db_client = engine.connect()
+    rstuf_table = Table("rstuf_targets", db_metadata, autoload_with=engine)
+
+    # validate if the CSV files are accessible
+    _check_csv_files(csv)
+    # import all CSV file(s) data to RSTUF DB without commiting
+    _import_csv_to_rstuf(db_client, rstuf_table, csv, succinct_roles)
+
+    # commit data into RSTUF DB
+    console.print("Import status: Commiting all data to the RSTUF database")
+    db_client.commit()
+    console.print("Import status: All data imported to RSTUF DB")
+
+    if skip_publish_targets:
+        console.print(
+            "Import status: Finshed. "
+            "Not targets published (`--skip-publish-targets`)"
+        )
+    else:
+        console.print("Import status: Submitting action publish targets")
+        publish_targets = request_server(
+            server, URL.publish_targets.value, Methods.post, headers=headers
+        )
+        if publish_targets.status_code != 202:
+            raise click.ClickException(
+                f"Failed to publish targets. {publish_targets.text}"
+            )
+        task_id = publish_targets.json()["data"]["task_id"]
+        console.print(f"Import status: Publish targets task id is {task_id}")
+
+        # monitor task status
+        result = task_status(task_id, server, headers, "Import status: task ")
+        if result is not None:
+            console.print("Import status: [green]Finished.[/]")

--- a/repository_service_tuf/cli/admin/import_targets.py
+++ b/repository_service_tuf/cli/admin/import_targets.py
@@ -101,8 +101,7 @@ def _get_succinct_roles(metadata_url: str) -> SuccinctRoles:
     if targets_delegations.succinct_roles is None:
         raise click.ClickException("Failed to get Targets succinct roles")
 
-    succinct_roles: SuccinctRoles = targets_delegations.succinct_roles
-    return succinct_roles
+    return targets_delegations.succinct_roles
 
 
 @admin.command()

--- a/repository_service_tuf/cli/admin/import_targets.py
+++ b/repository_service_tuf/cli/admin/import_targets.py
@@ -119,7 +119,7 @@ def _get_succinct_roles(metadata_url: str) -> SuccinctRoles:
     required=True,
     multiple=True,
     help=(
-        "CSV file to import. Multiple -csv parameters are allowed. "
+        "CSV file to import. Multiple --csv parameters are allowed. "
         "See rstuf CLI guide for more details."
     ),
 )

--- a/repository_service_tuf/helpers/api_client.py
+++ b/repository_service_tuf/helpers/api_client.py
@@ -69,7 +69,7 @@ def is_logged(server: str, token: str):
         return Login(state=False)
 
     elif response.status_code == 200:
-        data = response.json().get("data")
+        data = response.json().get("data", {})
         if data.get("expired") is False:
             return Login(state=True, data=data)
 
@@ -112,8 +112,8 @@ def get_headers(settings: Dict[str, str]) -> Dict[str, str]:
 
 def task_status(
     task_id: str, server: str, headers: Dict[str, str], title: Optional[str]
-) -> Dict[Any, str]:
-    received_state = []
+) -> Dict[str, Any]:
+    received_states = []
     while True:
         state_response = request_server(
             server, f"{URL.task.value}{task_id}", Methods.get, headers=headers
@@ -128,9 +128,9 @@ def task_status(
 
         if data:
             if state := data.get("state"):
-                if state not in received_state:
+                if state not in received_states:
                     console.print(f"{title}{state}")
-                    received_state.append(state)
+                    received_states.append(state)
                 else:
                     console.print(".", end="")
 

--- a/repository_service_tuf/helpers/api_client.py
+++ b/repository_service_tuf/helpers/api_client.py
@@ -93,7 +93,7 @@ def get_headers(settings: Dict[str, str]) -> Dict[str, str]:
         expired_admin = token_access_check.data.get("expired")
         if expired_admin is True:
             raise click.ClickException(
-                "Token expired. Run 'rstuf admin login'"
+                "The token has expired. Run 'rstuf admin login'"
             )
         else:
             headers = {"Authorization": f"Bearer {token}"}

--- a/repository_service_tuf/helpers/api_client.py
+++ b/repository_service_tuf/helpers/api_client.py
@@ -151,3 +151,17 @@ def task_status(
                 f"No data received {state_response.text}"
             )
         time.sleep(2)
+
+
+def publish_targets(server: str, headers: Dict[str, str]) -> str:
+    publish_targets = request_server(
+        server, URL.publish_targets.value, Methods.post, headers=headers
+    )
+    if publish_targets.status_code != 202:
+        raise click.ClickException(
+            f"Failed to publish targets. {publish_targets.status_code} "
+            f"{publish_targets.text}"
+        )
+    task_id = publish_targets.json()["data"]["task_id"]
+
+    return task_id

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,85 +1,88 @@
 -i https://pypi.org/simple
-alabaster==0.7.13; python_version >= '3.6'
-attrs==22.2.0; python_version >= '3.6'
-babel==2.11.0; python_version >= '3.6'
+alabaster==0.7.13 ; python_version >= '3.6'
+attrs==22.2.0 ; python_version >= '3.6'
+babel==2.11.0 ; python_version >= '3.6'
 bandit==1.7.4
-black==22.12.0
+black==23.1.0
 build==0.10.0
-cachetools==5.3.0; python_version ~= '3.7'
-certifi==2022.12.7; python_version >= '3.6'
-cfgv==3.3.1; python_full_version >= '3.6.1'
-chardet==5.1.0; python_version >= '3.7'
+cachetools==5.3.0 ; python_version ~= '3.7'
+certifi==2022.12.7 ; python_version >= '3.6'
+cfgv==3.3.1 ; python_full_version >= '3.6.1'
+chardet==5.1.0 ; python_version >= '3.7'
 charset-normalizer==3.0.1
 click==8.1.3
-colorama==0.4.6; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
+colorama==0.4.6 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
 coverage==7.1.0
 distlib==0.3.6
-docutils==0.19; python_version >= '3.7'
-editables==0.3; python_version > '3'
-exceptiongroup==1.1.0; python_version < '3.11'
-filelock==3.9.0; python_version >= '3.7'
+docutils==0.19 ; python_version >= '3.7'
+editables==0.3 ; python_version >= '3.1'
+exceptiongroup==1.1.0 ; python_version < '3.11'
+filelock==3.9.0 ; python_version >= '3.7'
 flake8==6.0.0
-gitdb==4.0.10; python_version >= '3.7'
-gitpython==3.1.30; python_version >= '3.7'
+gitdb==4.0.10 ; python_version >= '3.7'
+gitpython==3.1.30 ; python_version >= '3.7'
 hatchling==0.22.0
-identify==2.5.17; python_version >= '3.7'
-idna==3.4; python_version >= '3.5'
-imagesize==1.4.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-iniconfig==2.0.0; python_version >= '3.7'
+identify==2.5.17 ; python_version >= '3.7'
+idna==3.4 ; python_version >= '3.5'
+imagesize==1.4.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+iniconfig==2.0.0 ; python_version >= '3.7'
 isort==5.12.0
-jinja2==3.1.2; python_version >= '3.7'
-markupsafe==2.1.2; python_version >= '3.7'
-mccabe==0.7.0; python_version >= '3.6'
+jinja2==3.1.2 ; python_version >= '3.7'
+markupsafe==2.1.2 ; python_version >= '3.7'
+mccabe==0.7.0 ; python_version >= '3.6'
 mypy==0.991
-mypy-extensions==0.4.3
-nodeenv==1.7.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
-packaging==23.0; python_version > '3'
-pathspec==0.11.0; python_version >= '3.7'
-pbr==5.11.1; python_version >= '2.6'
-pip==22.3.1
-platformdirs==2.6.2; python_version >= '3.7'
-pluggy==1.0.0; python_version > '3'
-pre-commit==3.0.2
+mypy-extensions==1.0.0 ; python_version >= '3.5'
+nodeenv==1.7.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
+packaging==23.0 ; python_version >= '3.1'
+pathspec==0.11.0 ; python_version >= '3.7'
+pbr==5.11.1 ; python_version >= '2.6'
+pip==23.0
+platformdirs==2.6.2 ; python_version >= '3.7'
+pluggy==1.0.0 ; python_version >= '3.1'
+pre-commit==3.0.4
 pretend==1.0.9
-pycodestyle==2.10.0; python_version >= '3.6'
-pyflakes==3.0.1; python_version >= '3.6'
-pygments==2.14.0; python_version >= '3.6'
-pyproject-api==1.5.0; python_version >= '3.7'
-pyproject-hooks==1.0.0; python_version >= '3.7'
+pycodestyle==2.10.0 ; python_version >= '3.6'
+pyflakes==3.0.1 ; python_version >= '3.6'
+pygments==2.14.0 ; python_version >= '3.6'
+pyproject-api==1.5.0 ; python_version >= '3.7'
+pyproject-hooks==1.0.0 ; python_version >= '3.7'
 pytest==7.2.1
 pytz==2022.7.1
-pyyaml==6.0; python_version >= '3.6'
+pyyaml==6.0 ; python_version >= '3.6'
 requests==2.28.2
-setuptools==67.0.0; python_version >= '3.7'
-smmap==5.0.0; python_version >= '3.6'
+setuptools==67.1.0 ; python_version >= '3.7'
+smmap==5.0.0 ; python_version >= '3.6'
 snowballstemmer==2.2.0
 sphinx==6.1.3
 sphinx-rtd-theme==0.5.1
 sphinxcontrib-applehelp==1.0.4
 sphinxcontrib-devhelp==1.0.2
-sphinxcontrib-htmlhelp==2.0.0
+sphinxcontrib-htmlhelp==2.0.1
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-plantuml==0.24.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
-stevedore==4.1.1; python_full_version >= '3.8.0'
-tomli==2.0.1; python_version > '3'
-tox==4.4.2
+stevedore==4.1.1 ; python_version >= '3.8'
+tomli==2.0.1 ; python_version >= '3.1'
+tox==4.4.4
 types-requests==2.28.11.8
 types-urllib3==1.26.25.4
-typing-extensions==4.4.0; python_version >= '3.7'
-urllib3==1.26.14; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
-virtualenv==20.17.1; python_version >= '3.6'
+typing-extensions==4.4.0 ; python_version >= '3.7'
+urllib3==1.26.14 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
+virtualenv==20.18.0 ; python_version >= '3.7'
 cffi==1.15.1
 configobj==5.0.8
 cryptography==39.0.0
 dynaconf[ini]==3.1.11
-markdown-it-py==2.1.0; python_version >= '3.7'
-mdurl==0.1.2; python_version >= '3.7'
+greenlet==2.0.2 ; platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))
+markdown-it-py==2.1.0 ; python_version >= '3.7'
+mdurl==0.1.2 ; python_version >= '3.7'
+psycopg2==2.9.5
 pycparser==2.21
 pynacl==1.5.0
 rich==13.3.1
 rich-click==1.6.1
 securesystemslib[crypto]==0.26.0
-six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
+six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+sqlalchemy==2.0.1
 tuf==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,22 +1,26 @@
 -i https://pypi.org/simple
-certifi==2022.12.7; python_version >= '3.6'
+certifi==2022.12.7 ; python_version >= '3.6'
 cffi==1.15.1
 charset-normalizer==3.0.1
 click==8.1.3
 configobj==5.0.8
 cryptography==39.0.0
 dynaconf[ini]==3.1.11
-idna==3.4; python_version >= '3.5'
+greenlet==2.0.2 ; platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))
+idna==3.4 ; python_version >= '3.5'
 isort==5.12.0
-markdown-it-py==2.1.0; python_version >= '3.7'
-mdurl==0.1.2; python_version >= '3.7'
+markdown-it-py==2.1.0 ; python_version >= '3.7'
+mdurl==0.1.2 ; python_version >= '3.7'
+psycopg2==2.9.5
 pycparser==2.21
-pygments==2.14.0; python_version >= '3.6'
+pygments==2.14.0 ; python_version >= '3.6'
 pynacl==1.5.0
 requests==2.28.2
 rich==13.3.1
 rich-click==1.6.1
 securesystemslib[crypto]==0.26.0
-six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
+six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+sqlalchemy==2.0.1
 tuf==2.0.0
-urllib3==1.26.14; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
+typing-extensions==4.4.0 ; python_version >= '3.7'
+urllib3==1.26.14 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'

--- a/tests/unit/cli/admin/test_ceremony.py
+++ b/tests/unit/cli/admin/test_ceremony.py
@@ -71,177 +71,6 @@ class TestCeremonyGroupCLI:
         assert "No message available." in str(err)
         assert mocked_request_server.json.calls == [pretend.call()]
 
-    def test__bootstrap_state(self, monkeypatch):
-        fake_response_started = pretend.stub(
-            status_code=200,
-            json=pretend.call_recorder(
-                lambda: {
-                    "data": {
-                        "state": "STARTED",
-                    }
-                }
-            ),
-        )
-        fake_response_success = pretend.stub(
-            status_code=200,
-            json=pretend.call_recorder(
-                lambda: {
-                    "data": {
-                        "state": "SUCCESS",
-                        "result": {"details": {"bootstrap": True}},
-                    }
-                }
-            ),
-        )
-        mocked_request_server = MagicMock()
-        mocked_request_server.side_effect = [
-            fake_response_started,
-            fake_response_success,
-        ]
-        monkeypatch.setattr(ceremony, "request_server", mocked_request_server)
-
-        result = ceremony._bootstrap_state(
-            "task_id_123", "http://fake-server", {}
-        )
-        assert result is None
-        assert fake_response_started.json.calls == [pretend.call()]
-        assert fake_response_success.json.calls == [pretend.call()]
-
-    def test__bootstrap_state_without_bootstrap_true(self, monkeypatch):
-        fake_response_started = pretend.stub(
-            status_code=200,
-            json=pretend.call_recorder(
-                lambda: {
-                    "data": {
-                        "state": "STARTED",
-                    }
-                }
-            ),
-        )
-        fake_response_success = pretend.stub(
-            status_code=200,
-            json=pretend.call_recorder(
-                lambda: {
-                    "data": {
-                        "state": "SUCCESS",
-                    }
-                }
-            ),
-        )
-        mocked_request_server = MagicMock()
-        mocked_request_server.side_effect = [
-            fake_response_started,
-            fake_response_success,
-        ]
-        monkeypatch.setattr(ceremony, "request_server", mocked_request_server)
-
-        with pytest.raises(ClickException) as err:
-            ceremony._bootstrap_state("task_id_123", "http://fake-server", {})
-
-        assert "Something went wrong, result:" in str(err)
-        assert fake_response_started.json.calls == [pretend.call()]
-        assert fake_response_success.json.calls == [pretend.call()]
-
-    def test__bootstrap_state_task_failure(self, monkeypatch):
-        fake_response_started = pretend.stub(
-            status_code=200,
-            json=pretend.call_recorder(
-                lambda: {
-                    "data": {
-                        "state": "STARTED",
-                        "result": {"details": {"bootstrap": True}},
-                    }
-                }
-            ),
-        )
-        fake_response_success = pretend.stub(
-            status_code=200,
-            json=pretend.call_recorder(
-                lambda: {
-                    "data": {
-                        "state": "FAILURE",
-                        "result": "SomeException: bla bla bla",
-                    }
-                }
-            ),
-            text="{'data': {'state': 'FAILURE','result': 'SomeException'}}",
-        )
-        mocked_request_server = MagicMock()
-        mocked_request_server.side_effect = [
-            fake_response_started,
-            fake_response_success,
-        ]
-        monkeypatch.setattr(ceremony, "request_server", mocked_request_server)
-
-        with pytest.raises(ClickException) as err:
-            ceremony._bootstrap_state("task_id_123", "http://fake-server", {})
-
-        assert "Failed:" in str(err)
-        assert fake_response_started.json.calls == [pretend.call()]
-        assert fake_response_success.json.calls == [pretend.call()]
-
-    def test__bootstrap_state_not_200(self, monkeypatch):
-        fake_response_started = pretend.stub(
-            status_code=200,
-            json=pretend.call_recorder(
-                lambda: {
-                    "data": {
-                        "state": "STARTED",
-                        "result": {"details": {"bootstrap": True}},
-                    }
-                }
-            ),
-        )
-        fake_response_success = pretend.stub(
-            status_code=400,
-            text="Bad request",
-        )
-        mocked_request_server = MagicMock()
-        mocked_request_server.side_effect = [
-            fake_response_started,
-            fake_response_success,
-        ]
-        monkeypatch.setattr(ceremony, "request_server", mocked_request_server)
-
-        with pytest.raises(ClickException) as err:
-            ceremony._bootstrap_state("task_id_123", "http://fake-server", {})
-        assert "Unexpected response Bad request" in str(err)
-        assert fake_response_started.json.calls == [pretend.call()]
-
-    def test__bootstrap_state_bootstrap_no_data(self, monkeypatch):
-        fake_response = pretend.stub(
-            status_code=200,
-            json=pretend.call_recorder(lambda: {"data": {}}),
-            text=str("{'data': {}}"),
-        )
-
-        monkeypatch.setattr(
-            ceremony, "request_server", lambda *a, **kw: fake_response
-        )
-
-        with pytest.raises(ClickException) as err:
-            ceremony._bootstrap_state("task_id_123", "http://fake-server", {})
-
-        assert "No data received" in str(err)
-        assert fake_response.json.calls == [pretend.call()]
-
-    def test__bootstrap_state_bootstrap_no_state(self, monkeypatch):
-        fake_response = pretend.stub(
-            status_code=200,
-            json=pretend.call_recorder(lambda: {"data": {"state": None}}),
-            text=str("{'data': {}}"),
-        )
-
-        monkeypatch.setattr(
-            ceremony, "request_server", lambda *a, **kw: fake_response
-        )
-
-        with pytest.raises(ClickException) as err:
-            ceremony._bootstrap_state("task_id_123", "http://fake-server", {})
-
-        assert "No state in data received" in str(err)
-        assert fake_response.json.calls == [pretend.call()]
-
     def test_ceremony(self, client, test_context):
         test_result = client.invoke(ceremony.ceremony, obj=test_context)
         assert test_result.exit_code == 1
@@ -526,13 +355,10 @@ class TestCeremonyGroupCLI:
             "y",
         ]
 
-        mocked_check_server = pretend.call_recorder(
+        mocked_get_headers = pretend.call_recorder(
             lambda s: {"Authorization": "Bearer test"}
         )
-        monkeypatch.setattr(
-            "repository_service_tuf.cli.admin.ceremony._check_server",
-            mocked_check_server,
-        )
+        monkeypatch.setattr(ceremony, "get_headers", mocked_get_headers)
 
         fake_response_get = pretend.stub(
             status_code=200,
@@ -585,13 +411,10 @@ class TestCeremonyGroupCLI:
     def test_ceremony_with_flag_bootstrap_already_done(
         self, client, monkeypatch, test_context
     ):
-        mocked_check_server = pretend.call_recorder(
+        mocked_get_headers = pretend.call_recorder(
             lambda s: {"Authorization": "Bearer test"}
         )
-        monkeypatch.setattr(
-            "repository_service_tuf.cli.admin.ceremony._check_server",
-            mocked_check_server,
-        )
+        monkeypatch.setattr(ceremony, "get_headers", mocked_get_headers)
 
         mocked_request_server = pretend.stub(
             status_code=200,
@@ -622,13 +445,10 @@ class TestCeremonyGroupCLI:
     def test_ceremony_with_flag_bootstrap_forbidden(
         self, client, monkeypatch, test_context
     ):
-        mocked_check_server = pretend.call_recorder(
+        mocked_get_headers = pretend.call_recorder(
             lambda s: {"Authorization": "Bearer test"}
         )
-        monkeypatch.setattr(
-            "repository_service_tuf.cli.admin.ceremony._check_server",
-            mocked_check_server,
-        )
+        monkeypatch.setattr(ceremony, "get_headers", mocked_get_headers)
 
         mocked_request_server = pretend.stub(
             status_code=401,
@@ -707,14 +527,10 @@ class TestCeremonyGroupCLI:
             "y",
         ]
 
-        mocked_check_server = pretend.call_recorder(
+        mocked_get_headers = pretend.call_recorder(
             lambda s: {"Authorization": "Bearer test"}
         )
-        monkeypatch.setattr(
-            "repository_service_tuf.cli.admin.ceremony._check_server",
-            mocked_check_server,
-        )
-
+        monkeypatch.setattr(ceremony, "get_headers", mocked_get_headers)
         fake_response_get = pretend.stub(
             status_code=200,
             json=pretend.call_recorder(lambda: {"bootstrap": False}),
@@ -811,13 +627,10 @@ class TestCeremonyGroupCLI:
             "y",
         ]
 
-        mocked_check_server = pretend.call_recorder(
+        mocked_get_headers = pretend.call_recorder(
             lambda s: {"Authorization": "Bearer test"}
         )
-        monkeypatch.setattr(
-            "repository_service_tuf.cli.admin.ceremony._check_server",
-            mocked_check_server,
-        )
+        monkeypatch.setattr(ceremony, "get_headers", mocked_get_headers)
 
         fake_response_get = pretend.stub(
             status_code=200,

--- a/tests/unit/cli/admin/test_ceremony.py
+++ b/tests/unit/cli/admin/test_ceremony.py
@@ -457,7 +457,7 @@ class TestCeremonyGroupCLI:
                     "detail": "Unauthorized.",
                 }
             ),
-            text="Unauthorized."
+            text="Unauthorized.",
         )
 
         monkeypatch.setattr(

--- a/tests/unit/cli/admin/test_ceremony.py
+++ b/tests/unit/cli/admin/test_ceremony.py
@@ -457,6 +457,7 @@ class TestCeremonyGroupCLI:
                     "detail": "Unauthorized.",
                 }
             ),
+            text="Unauthorized."
         )
 
         monkeypatch.setattr(

--- a/tests/unit/cli/admin/test_import_targets.py
+++ b/tests/unit/cli/admin/test_import_targets.py
@@ -1,7 +1,6 @@
 import pytest
 import pretend
 import datetime
-from unittest.mock import Mock
 
 from repository_service_tuf.cli.admin import import_targets
 

--- a/tests/unit/cli/admin/test_import_targets.py
+++ b/tests/unit/cli/admin/test_import_targets.py
@@ -279,7 +279,7 @@ class TestImportTargetsGroupCLI:
         assert import_targets.is_logged.calls == [
             pretend.call("fake-server", "test-token")
         ]
-        import_targets.request_server.calls == [
+        assert import_targets.request_server.calls == [
             pretend.call(
                 "fake-server",
                 import_targets.URL.bootstrap.value,
@@ -395,7 +395,7 @@ class TestImportTargetsGroupCLI:
         assert import_targets.get_headers.calls == [
             pretend.call(test_context["settings"])
         ]
-        import_targets.request_server.calls == [
+        assert import_targets.request_server.calls == [
             pretend.call(
                 "fake-server",
                 import_targets.URL.bootstrap.value,
@@ -445,7 +445,7 @@ class TestImportTargetsGroupCLI:
         assert import_targets.get_headers.calls == [
             pretend.call(test_context["settings"])
         ]
-        import_targets.request_server.calls == [
+        assert import_targets.request_server.calls == [
             pretend.call(
                 "fake-server",
                 import_targets.URL.bootstrap.value,
@@ -519,7 +519,7 @@ class TestImportTargetsGroupCLI:
         assert import_targets.is_logged.calls == [
             pretend.call("fake-server", "test-token")
         ]
-        import_targets.request_server.calls == [
+        assert import_targets.request_server.calls == [
             pretend.call(
                 "fake-server",
                 import_targets.URL.bootstrap.value,

--- a/tests/unit/cli/admin/test_import_targets.py
+++ b/tests/unit/cli/admin/test_import_targets.py
@@ -1,6 +1,7 @@
-import pytest
-import pretend
 import datetime
+
+import pretend
+import pytest
 
 from repository_service_tuf.cli.admin import import_targets
 

--- a/tests/unit/cli/admin/test_import_targets.py
+++ b/tests/unit/cli/admin/test_import_targets.py
@@ -1,0 +1,541 @@
+import pytest
+import pretend
+import datetime
+from unittest.mock import Mock
+
+from repository_service_tuf.cli.admin import import_targets
+
+
+class TestImportTargetsFunctions:
+    def test__check_csv_files(self, monkeypatch):
+        monkeypatch.setattr(
+            import_targets.os.path,
+            "isfile",
+            pretend.call_recorder(lambda *a: True),
+        )
+
+        result = import_targets._check_csv_files(["1of2.csv", "2of2.csv"])
+        assert result is None
+        assert import_targets.os.path.isfile.calls == [
+            pretend.call("1of2.csv"),
+            pretend.call("2of2.csv"),
+        ]
+
+    def test__check_csv_files_file_not_found(self, monkeypatch):
+        monkeypatch.setattr(
+            import_targets.os.path,
+            "isfile",
+            pretend.call_recorder(lambda *a: False),
+        )
+
+        with pytest.raises(import_targets.click.ClickException) as err:
+            import_targets._check_csv_files(["1of2.csv", "2of2.csv"])
+
+        assert "CSV file(s) not found: 1of2.csv, 2of2.csv" in str(err)
+        assert import_targets.os.path.isfile.calls == [
+            pretend.call("1of2.csv"),
+            pretend.call("2of2.csv"),
+        ]
+
+    def test__parse_csv_data(self, monkeypatch):
+        fake_data = [
+            "path/file1;123;blake2b-256;hash1",
+            "path/file2;456;blake2b-256;hash2",
+        ]
+        fake_file_obj = pretend.stub(
+            __enter__=pretend.call_recorder(lambda: fake_data),
+            __exit__=pretend.call_recorder(lambda *a: None),
+            close=pretend.call_recorder(lambda: None),
+            read=pretend.call_recorder(lambda: fake_data),
+        )
+        monkeypatch.setitem(
+            import_targets.__builtins__, "open", lambda *a, **kw: fake_file_obj
+        )
+
+        fake_time = datetime.datetime(2019, 6, 16, 9, 5, 1)
+        fake_datetime = pretend.stub(
+            now=pretend.call_recorder(lambda: fake_time)
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf.cli.admin.import_targets.datetime",
+            fake_datetime,
+        )
+        succinct_roles = pretend.stub(
+            get_role_for_target=pretend.call_recorder(lambda *a: "bins-a")
+        )
+
+        result = import_targets._parse_csv_data("fake_file", succinct_roles)
+
+        assert result == [
+            {
+                "path": "path/file1",
+                "info": {"length": 123, "hashes": {"blake2b-256": "hash1"}},
+                "rolename": "bins-a",
+                "published": False,
+                "action": "ADD",
+                "last_update": datetime.datetime(2019, 6, 16, 9, 5, 1),
+            },
+            {
+                "path": "path/file2",
+                "info": {"length": 456, "hashes": {"blake2b-256": "hash2"}},
+                "rolename": "bins-a",
+                "published": False,
+                "action": "ADD",
+                "last_update": datetime.datetime(2019, 6, 16, 9, 5, 1),
+            },
+        ]
+
+    def test__import_csv_to_rstuf(self):
+        fake_rstuf_table = pretend.stub(
+            insert=pretend.call_recorder(lambda: None)
+        )
+        fake_db_client = pretend.stub(
+            execute=pretend.call_recorder(lambda *a: None)
+        )
+        import_targets._parse_csv_data = pretend.call_recorder(
+            lambda *a: [{"k1": "v1", "k2": "v2"}]
+        )
+
+        result = import_targets._import_csv_to_rstuf(
+            fake_db_client,
+            fake_rstuf_table,
+            ["csv1", "csv2"],
+            "fake_succinct_roles",
+        )
+
+        assert result is None
+        assert import_targets._parse_csv_data.calls == [
+            pretend.call("csv1", "fake_succinct_roles"),
+            pretend.call("csv2", "fake_succinct_roles"),
+        ]
+        assert fake_db_client.execute.calls == [
+            pretend.call(
+                fake_rstuf_table.insert(), [{"k1": "v1", "k2": "v2"}]
+            ),
+            pretend.call(
+                fake_rstuf_table.insert(), [{"k1": "v1", "k2": "v2"}]
+            ),
+        ]
+        assert fake_rstuf_table.insert.calls == [
+            pretend.call(),
+            pretend.call(),
+            pretend.call(),
+            pretend.call(),
+        ]
+
+    def test__import_csv_to_rstuf_duplicate_targets(self):
+        fake_rstuf_table = pretend.stub(
+            insert=pretend.raiser(
+                import_targets.IntegrityError("Duplicate", "param", "orig")
+            )
+        )
+        fake_db_client = pretend.stub(
+            execute=pretend.call_recorder(lambda *a: None)
+        )
+        import_targets._parse_csv_data = pretend.call_recorder(
+            lambda *a: [{"k1": "v1", "k2": "v2"}]
+        )
+
+        with pytest.raises(import_targets.click.ClickException) as err:
+            import_targets._import_csv_to_rstuf(
+                fake_db_client,
+                fake_rstuf_table,
+                ["csv1", "csv2"],
+                "fake_succinct_roles",
+            )
+
+        assert "ABORTED due duplicated targets." in str(err)
+        assert import_targets._parse_csv_data.calls == [
+            pretend.call("csv1", "fake_succinct_roles"),
+        ]
+
+    def test__get_succinct_roles(self, monkeypatch):
+        import_targets.request_server = pretend.call_recorder(
+            lambda *a: pretend.stub(status_code=200, text=b"data")
+        )
+        monkeypatch.setattr(
+            import_targets.json, "loads", lambda *a: "json_data"
+        )
+        import_targets.Metadata.from_dict = pretend.call_recorder(
+            lambda *a: pretend.stub(
+                signed=pretend.stub(
+                    delegations=pretend.stub(
+                        succinct_roles="fake_succinct_roles"
+                    )
+                )
+            )
+        )
+
+        result = import_targets._get_succinct_roles(
+            "http://127.0.0.1/metadata"
+        )
+        assert result == "fake_succinct_roles"
+
+    def test__get_succinct_roles_not_found_metadata(self, monkeypatch):
+        import_targets.request_server = pretend.call_recorder(
+            lambda *a: pretend.stub(status_code=404, text=b"data")
+        )
+
+        with pytest.raises(import_targets.click.ClickException) as err:
+            import_targets._get_succinct_roles("http://127.0.0.1/metadata")
+        assert "RSTUF Metadata Targets not found." in str(err)
+
+    def test__get_succinct_roles_no_delegations(self, monkeypatch):
+        import_targets.request_server = pretend.call_recorder(
+            lambda *a: pretend.stub(status_code=200, text=b"data")
+        )
+        monkeypatch.setattr(
+            import_targets.json, "loads", lambda *a: "json_data"
+        )
+        import_targets.Metadata.from_dict = pretend.call_recorder(
+            lambda *a: pretend.stub(signed=pretend.stub(delegations=None))
+        )
+
+        with pytest.raises(import_targets.click.ClickException) as err:
+            import_targets._get_succinct_roles("http://127.0.0.1/metadata")
+        assert "Failed to get Targets Delegations" in str(err)
+
+    def test__get_succinct_roles_no_succinct_roles(self, monkeypatch):
+        import_targets.request_server = pretend.call_recorder(
+            lambda *a: pretend.stub(status_code=200, text=b"data")
+        )
+        monkeypatch.setattr(
+            import_targets.json, "loads", lambda *a: "json_data"
+        )
+        import_targets.Metadata.from_dict = pretend.call_recorder(
+            lambda *a: pretend.stub(
+                signed=pretend.stub(
+                    delegations=pretend.stub(succinct_roles=None)
+                )
+            )
+        )
+
+        with pytest.raises(import_targets.click.ClickException) as err:
+            import_targets._get_succinct_roles("http://127.0.0.1/metadata")
+        assert "Failed to get Targets succinct roles" in str(err)
+
+
+class TestImportTargetsGroupCLI:
+    def test_import_targets(self, client, test_context):
+        test_context["settings"].SERVER = "fake-server"
+        test_context["settings"].TOKEN = "test-token"
+
+        import_targets.is_logged = pretend.call_recorder(
+            lambda *a: pretend.stub(state=True)
+        )
+        import_targets.get_headers = pretend.call_recorder(
+            lambda *a: "headers"
+        )
+        fake_response = pretend.stub(
+            status_code=200,
+            json=pretend.call_recorder(lambda: {"data": {"bootstrap": True}}),
+        )
+        import_targets.request_server = pretend.call_recorder(
+            lambda *a, **kw: fake_response
+        )
+        import_targets._get_succinct_roles = pretend.call_recorder(
+            lambda *a: "fake_succinct_roles"
+        )
+        import_targets.create_engine = pretend.call_recorder(
+            lambda *a: pretend.stub(
+                connect=pretend.call_recorder(
+                    lambda: pretend.stub(
+                        commit=pretend.call_recorder(lambda: None)
+                    )
+                )
+            )
+        )
+        import_targets.Table = pretend.call_recorder(
+            lambda *a, **kw: "rstuf_table"
+        )
+        import_targets._check_csv_files = pretend.call_recorder(
+            lambda **kw: None
+        )
+        import_targets._import_csv_to_rstuf = pretend.call_recorder(
+            lambda *a: None
+        )
+        import_targets.publish_targets = pretend.call_recorder(
+            lambda *a: "fake_task_id"
+        )
+        import_targets.task_status = pretend.call_recorder(
+            lambda *a: {"status": "SUCCESS"}
+        )
+
+        options = [
+            "-metadata-url",
+            "http://127.0.0.1/metadata/",
+            "-db-uri",
+            "postgresql://postgres:secret@127.0.0.1:5433",
+            "-csv",
+            "targets1of2.csv",
+            "-csv",
+            "targets2of2.csv",
+        ]
+        result = client.invoke(
+            import_targets.import_targets, options, obj=test_context
+        )
+        assert result.exit_code == 0, result.output
+        assert "Finished." in result.output
+        assert import_targets.is_logged.calls == [
+            pretend.call("fake-server", "test-token")
+        ]
+        import_targets.request_server.calls == [
+            pretend.call(
+                "fake-server",
+                import_targets.URL.bootstrap.value,
+                import_targets.Methods.get,
+                headers="headers",
+            )
+        ]
+        assert import_targets.get_headers.calls == [
+            pretend.call(test_context["settings"])
+        ]
+        assert fake_response.json.calls == [pretend.call()]
+        assert import_targets.create_engine.calls == [
+            pretend.call("postgresql://postgres:secret@127.0.0.1:5433")
+        ]
+        assert import_targets._check_csv_files.calls == [
+            pretend.call(csv_files=("targets1of2.csv", "targets2of2.csv"))
+        ]
+        assert import_targets.publish_targets.calls == [
+            pretend.call("fake-server", "headers")
+        ]
+        assert import_targets.task_status.calls == [
+            pretend.call(
+                "fake_task_id",
+                "fake-server",
+                "headers",
+                "Import status: task ",
+            )
+        ]
+
+    def test_import_targets_expired(self, client, test_context):
+        test_context["settings"].SERVER = "fake-server"
+        test_context["settings"].TOKEN = "test-token"
+
+        import_targets.is_logged = pretend.call_recorder(
+            lambda *a: pretend.stub(state=False, data={"expired": True})
+        )
+
+        options = [
+            "-metadata-url",
+            "http://127.0.0.1/metadata/",
+            "-db-uri",
+            "postgresql://postgres:secret@127.0.0.1:5433",
+            "-csv",
+            "targets1of2.csv",
+            "-csv",
+            "targets2of2.csv",
+        ]
+
+        result = client.invoke(
+            import_targets.import_targets, options, obj=test_context
+        )
+        assert result.exit_code == 1, result.output
+        assert "Try re-login" in result.output
+
+    def test_import_never_logged(self, client, test_context):
+        import_targets.is_logged = pretend.call_recorder(
+            lambda *a: pretend.stub(state=False, data={"expired": True})
+        )
+
+        options = [
+            "-metadata-url",
+            "http://127.0.0.1/metadata/",
+            "-db-uri",
+            "postgresql://postgres:secret@127.0.0.1:5433",
+            "-csv",
+            "targets1of2.csv",
+            "-csv",
+            "targets2of2.csv",
+        ]
+
+        result = client.invoke(
+            import_targets.import_targets, options, obj=test_context
+        )
+        assert result.exit_code == 1, result.output
+        assert "Login first. Run 'rstuf admin login'" in result.output
+
+    def test_import_targets_bootstrap_check_failed(self, client, test_context):
+        test_context["settings"].SERVER = "fake-server"
+        test_context["settings"].TOKEN = "test-token"
+
+        import_targets.is_logged = pretend.call_recorder(
+            lambda *a: pretend.stub(state=True)
+        )
+        import_targets.get_headers = pretend.call_recorder(
+            lambda *a: "headers"
+        )
+        fake_response = pretend.stub(
+            status_code=500,
+            text="Internal Error",
+        )
+        import_targets.request_server = pretend.call_recorder(
+            lambda *a, **kw: fake_response
+        )
+
+        options = [
+            "-metadata-url",
+            "http://127.0.0.1/metadata/",
+            "-db-uri",
+            "postgresql://postgres:secret@127.0.0.1:5433",
+            "-csv",
+            "targets1of2.csv",
+            "-csv",
+            "targets2of2.csv",
+        ]
+        result = client.invoke(
+            import_targets.import_targets, options, obj=test_context
+        )
+        assert result.exit_code == 1, result.output
+        assert "Error 500 Internal Error" in result.output
+        assert import_targets.is_logged.calls == [
+            pretend.call("fake-server", "test-token")
+        ]
+        assert import_targets.get_headers.calls == [
+            pretend.call(test_context["settings"])
+        ]
+        import_targets.request_server.calls == [
+            pretend.call(
+                "fake-server",
+                import_targets.URL.bootstrap.value,
+                import_targets.Methods.get,
+                headers="headers",
+            )
+        ]
+
+    def test_import_targets_without_bootstrap(self, client, test_context):
+        test_context["settings"].SERVER = "fake-server"
+        test_context["settings"].TOKEN = "test-token"
+
+        import_targets.is_logged = pretend.call_recorder(
+            lambda *a: pretend.stub(state=True)
+        )
+        import_targets.get_headers = pretend.call_recorder(
+            lambda *a: "headers"
+        )
+        fake_response = pretend.stub(
+            status_code=200,
+            json=pretend.call_recorder(lambda: {"data": {"bootstrap": False}}),
+        )
+        import_targets.request_server = pretend.call_recorder(
+            lambda *a, **kw: fake_response
+        )
+
+        options = [
+            "-metadata-url",
+            "http://127.0.0.1/metadata/",
+            "-db-uri",
+            "postgresql://postgres:secret@127.0.0.1:5433",
+            "-csv",
+            "targets1of2.csv",
+            "-csv",
+            "targets2of2.csv",
+        ]
+        result = client.invoke(
+            import_targets.import_targets, options, obj=test_context
+        )
+        assert result.exit_code == 1, result.output
+        assert (
+            "import-targets` requires bootstrap process done." in result.output
+        )
+        assert import_targets.is_logged.calls == [
+            pretend.call("fake-server", "test-token")
+        ]
+        assert import_targets.get_headers.calls == [
+            pretend.call(test_context["settings"])
+        ]
+        import_targets.request_server.calls == [
+            pretend.call(
+                "fake-server",
+                import_targets.URL.bootstrap.value,
+                import_targets.Methods.get,
+                headers="headers",
+            )
+        ]
+
+    def test_import_targets_skip_publish_targets(self, client, test_context):
+        test_context["settings"].SERVER = "fake-server"
+        test_context["settings"].TOKEN = "test-token"
+
+        import_targets.is_logged = pretend.call_recorder(
+            lambda *a: pretend.stub(state=True)
+        )
+        import_targets.get_headers = pretend.call_recorder(
+            lambda *a: "headers"
+        )
+        fake_response = pretend.stub(
+            status_code=200,
+            json=pretend.call_recorder(lambda: {"data": {"bootstrap": True}}),
+        )
+        import_targets.request_server = pretend.call_recorder(
+            lambda *a, **kw: fake_response
+        )
+        import_targets._get_succinct_roles = pretend.call_recorder(
+            lambda *a: "fake_succinct_roles"
+        )
+        import_targets.create_engine = pretend.call_recorder(
+            lambda *a: pretend.stub(
+                connect=pretend.call_recorder(
+                    lambda: pretend.stub(
+                        commit=pretend.call_recorder(lambda: None)
+                    )
+                )
+            )
+        )
+        import_targets.Table = pretend.call_recorder(
+            lambda *a, **kw: "rstuf_table"
+        )
+        import_targets._check_csv_files = pretend.call_recorder(
+            lambda **kw: None
+        )
+        import_targets._import_csv_to_rstuf = pretend.call_recorder(
+            lambda *a: None
+        )
+        import_targets.publish_targets = pretend.call_recorder(
+            lambda *a: "fake_task_id"
+        )
+        import_targets.task_status = pretend.call_recorder(
+            lambda *a: {"status": "SUCCESS"}
+        )
+
+        options = [
+            "-metadata-url",
+            "http://127.0.0.1/metadata/",
+            "-db-uri",
+            "postgresql://postgres:secret@127.0.0.1:5433",
+            "-csv",
+            "targets1of2.csv",
+            "-csv",
+            "targets2of2.csv",
+            "--skip-publish-targets",
+        ]
+        result = client.invoke(
+            import_targets.import_targets, options, obj=test_context
+        )
+        assert result.exit_code == 0, result.output
+        assert "Finished." in result.output
+        assert "Not targets published" in result.output
+        assert import_targets.is_logged.calls == [
+            pretend.call("fake-server", "test-token")
+        ]
+        import_targets.request_server.calls == [
+            pretend.call(
+                "fake-server",
+                import_targets.URL.bootstrap.value,
+                import_targets.Methods.get,
+                headers="headers",
+            )
+        ]
+        assert import_targets.get_headers.calls == [
+            pretend.call(test_context["settings"])
+        ]
+        assert fake_response.json.calls == [pretend.call()]
+        assert import_targets.create_engine.calls == [
+            pretend.call("postgresql://postgres:secret@127.0.0.1:5433")
+        ]
+        assert import_targets._check_csv_files.calls == [
+            pretend.call(csv_files=("targets1of2.csv", "targets2of2.csv"))
+        ]
+        assert import_targets.publish_targets.calls == []
+        assert import_targets.task_status.calls == []

--- a/tests/unit/helpers/test_api_client.py
+++ b/tests/unit/helpers/test_api_client.py
@@ -132,7 +132,7 @@ class TestAPIClient:
 
     def test_get_headers(self):
         api_client.is_logged = pretend.call_recorder(
-            lambda *a, **kw: api_client.Login(
+            lambda *a: api_client.Login(
                 state=True, data={"data": {"expired": False}}
             )
         )
@@ -165,9 +165,7 @@ class TestAPIClient:
 
     def test_get_headers_is_logged_state_false(self):
         api_client.is_logged = pretend.call_recorder(
-            lambda *a, **kw: api_client.Login(
-                state=False, data={"expired": False}
-            )
+            lambda *a: api_client.Login(state=False, data={"expired": False})
         )
 
         with pytest.raises(api_client.click.ClickException) as err:
@@ -182,9 +180,7 @@ class TestAPIClient:
 
     def test_get_headers_is_logged_state_true_expired_token(self):
         api_client.is_logged = pretend.call_recorder(
-            lambda *a, **kw: api_client.Login(
-                state=True, data={"expired": True}
-            )
+            lambda *a: api_client.Login(state=True, data={"expired": True})
         )
 
         with pytest.raises(api_client.click.ClickException) as err:
@@ -199,9 +195,7 @@ class TestAPIClient:
 
     def test_get_headers_unexpected_error(self):
         api_client.is_logged = pretend.call_recorder(
-            lambda *a, **kw: api_client.Login(
-                state=True, data={"expired": False}
-            )
+            lambda *a: api_client.Login(state=True, data={"expired": False})
         )
         api_client.request_server = pretend.call_recorder(
             lambda *a, **kw: pretend.stub(status_code=500, text="error body")

--- a/tests/unit/helpers/test_api_client.py
+++ b/tests/unit/helpers/test_api_client.py
@@ -2,57 +2,362 @@
 #
 # SPDX-License-Identifier: MIT
 
+from unittest.mock import Mock
+
 import pretend
 import pytest
 
-from repository_service_tuf.helpers.api_client import Methods, request_server
+from repository_service_tuf.helpers import api_client
 
 
-class TestAPICLient:
-    def test_request_server_get(self, monkeypatch):
-
+class TestAPIClient:
+    def test_request_server_get(self):
         fake_response = pretend.stub(
             status_code=200,
             json=pretend.call_recorder(lambda: {"key": "value"}),
         )
-        fake_requests = pretend.stub(
+        api_client.requests = pretend.stub(
             get=pretend.call_recorder(lambda *a, **kw: fake_response)
         )
-        monkeypatch.setattr(
-            "repository_service_tuf.helpers.api_client.requests", fake_requests
+        result = api_client.request_server(
+            "http://server", "url", api_client.Methods.get
         )
 
-        request_server("http://server", "url", Methods.get)
-
-        assert fake_requests.get.calls == [
+        assert result == fake_response
+        assert api_client.requests.get.calls == [
             pretend.call(
                 "http://server/url", json=None, data=None, headers=None
             )
         ]
 
-    def test_request_server_post(self, monkeypatch):
+    def test_request_server_post(self):
         fake_response = pretend.stub(
             status_code=200,
             json=pretend.call_recorder(lambda: {"key": "value"}),
         )
-        fake_requests = pretend.stub(
+        api_client.requests = pretend.stub(
             post=pretend.call_recorder(lambda *a, **kw: fake_response)
         )
-        monkeypatch.setattr(
-            "repository_service_tuf.helpers.api_client.requests", fake_requests
+
+        result = api_client.request_server(
+            "http://server", "url", api_client.Methods.post, {"k": "v"}
         )
 
-        request_server("http://server", "url", Methods.post, {"k": "v"})
-
-        assert fake_requests.post.calls == [
+        assert result == fake_response
+        assert api_client.requests.post.calls == [
             pretend.call(
                 "http://server/url", json={"k": "v"}, data=None, headers=None
             )
         ]
 
-    def test_request_server_invalid_method(self, monkeypatch):
-
+    def test_request_server_invalid_method(self):
         with pytest.raises(ValueError) as err:
-            request_server("http://server", "url", "Invalid", {"k": "v"})
+            api_client.request_server(
+                "http://server", "url", "Invalid", {"k": "v"}
+            )
 
         assert "Internal Error. Invalid HTTP/S Method." in str(err.value)
+
+    def test_request_server_ConnectionError(self):
+        api_client.requests = pretend.stub(
+            post=pretend.raiser(api_client.ConnectionError("Failed request"))
+        )
+        with pytest.raises(api_client.click.exceptions.ClickException) as err:
+            api_client.request_server(
+                "http://server", "url", api_client.Methods.post, {"k": "v"}
+            )
+
+        assert "Failed to connect to http://server" in str(err.value)
+
+    def test_is_logged(self):
+        fake_response = pretend.stub(
+            status_code=200,
+            json=pretend.call_recorder(lambda: {"data": {"expired": False}}),
+        )
+        api_client.request_server = pretend.call_recorder(
+            lambda *a, **kw: fake_response
+        )
+
+        result = api_client.is_logged("http://server", "fake_token")
+        assert result == api_client.Login(state=True, data={"expired": False})
+        assert api_client.request_server.calls == [
+            pretend.call(
+                "http://server",
+                "api/v1/token/?token=fake_token",
+                api_client.Methods.get,
+                headers={"Authorization": "Bearer fake_token"},
+            )
+        ]
+
+    def test_is_logged_401(self):
+        fake_response = pretend.stub(
+            status_code=401,
+        )
+        api_client.request_server = pretend.call_recorder(
+            lambda *a, **kw: fake_response
+        )
+
+        result = api_client.is_logged("http://server", "fake_token")
+        assert result == api_client.Login(state=False, data=None)
+        assert api_client.request_server.calls == [
+            pretend.call(
+                "http://server",
+                "api/v1/token/?token=fake_token",
+                api_client.Methods.get,
+                headers={"Authorization": "Bearer fake_token"},
+            )
+        ]
+
+    def test_is_logged_500(self):
+        fake_response = pretend.stub(
+            status_code=500,
+            text="body",
+        )
+        api_client.request_server = pretend.call_recorder(
+            lambda *a, **kw: fake_response
+        )
+
+        with pytest.raises(api_client.click.ClickException) as err:
+            api_client.is_logged("http://server", "fake_token")
+
+        assert "Error 500 body" in str(err)
+        assert api_client.request_server.calls == [
+            pretend.call(
+                "http://server",
+                "api/v1/token/?token=fake_token",
+                api_client.Methods.get,
+                headers={"Authorization": "Bearer fake_token"},
+            )
+        ]
+
+    def test_get_headers(self):
+        api_client.is_logged = pretend.call_recorder(
+            lambda *a, **kw: api_client.Login(
+                state=True, data={"data": {"expired": False}}
+            )
+        )
+        api_client.request_server = pretend.call_recorder(
+            lambda *a, **kw: pretend.stub(status_code=200)
+        )
+
+        result = api_client.get_headers(
+            {"SERVER": "http://server", "TOKEN": "fake_token"}
+        )
+
+        assert result == {"Authorization": "Bearer fake_token"}
+        assert api_client.is_logged.calls == [
+            pretend.call("http://server", "fake_token")
+        ]
+        assert api_client.request_server.calls == [
+            pretend.call(
+                "http://server",
+                api_client.URL.bootstrap.value,
+                api_client.Methods.get,
+                headers={"Authorization": "Bearer fake_token"},
+            )
+        ]
+
+    def test_get_headers_never_logged(self):
+        with pytest.raises(api_client.click.ClickException) as err:
+            api_client.get_headers({})
+
+        assert "Login first. Run 'rstuf admin login'" in str(err)
+
+    def test_get_headers_is_logged_state_false(self):
+        api_client.is_logged = pretend.call_recorder(
+            lambda *a, **kw: api_client.Login(
+                state=False, data={"expired": False}
+            )
+        )
+
+        with pytest.raises(api_client.click.ClickException) as err:
+            api_client.get_headers(
+                {"SERVER": "http://server", "TOKEN": "fake_token"}
+            )
+
+        assert "re-login" in str(err)
+        assert api_client.is_logged.calls == [
+            pretend.call("http://server", "fake_token")
+        ]
+
+    def test_get_headers_is_logged_state_true_expired_token(self):
+        api_client.is_logged = pretend.call_recorder(
+            lambda *a, **kw: api_client.Login(
+                state=True, data={"expired": True}
+            )
+        )
+
+        with pytest.raises(api_client.click.ClickException) as err:
+            api_client.get_headers(
+                {"SERVER": "http://server", "TOKEN": "fake_token"}
+            )
+
+        assert "Token expired" in str(err)
+        assert api_client.is_logged.calls == [
+            pretend.call("http://server", "fake_token")
+        ]
+
+    def test_get_headers_unexpected_error(self):
+        api_client.is_logged = pretend.call_recorder(
+            lambda *a, **kw: api_client.Login(
+                state=True, data={"expired": False}
+            )
+        )
+        api_client.request_server = pretend.call_recorder(
+            lambda *a, **kw: pretend.stub(status_code=500, text="error body")
+        )
+        with pytest.raises(api_client.click.ClickException) as err:
+            api_client.get_headers(
+                {"SERVER": "http://server", "TOKEN": "fake_token"}
+            )
+
+        assert "Unexpected error" in str(err)
+        assert api_client.is_logged.calls == [
+            pretend.call("http://server", "fake_token")
+        ]
+
+    def test_task_status(self):
+        fake_json = Mock()
+        fake_json.side_effect = [
+            {"data": {"state": "STARTED", "k": "v"}},
+            {"data": {"state": "RUNNING", "k": "v"}},
+            {"data": {"state": "RUNNING", "k": "v"}},
+            {"data": {"state": "SUCCESS", "k": "v"}},
+        ]
+        api_client.request_server = pretend.call_recorder(
+            lambda *a, **kw: pretend.stub(status_code=200, json=fake_json)
+        )
+
+        result = api_client.task_status(
+            "task_id", "http://server", {"Auth": "Token"}, "Test task: "
+        )
+
+        assert result == {"state": "SUCCESS", "k": "v"}
+        assert api_client.request_server.calls == [
+            pretend.call(
+                "http://server",
+                "api/v1/task/?task_id=task_id",
+                api_client.Methods.get,
+                headers={"Auth": "Token"},
+            ),
+            pretend.call(
+                "http://server",
+                "api/v1/task/?task_id=task_id",
+                api_client.Methods.get,
+                headers={"Auth": "Token"},
+            ),
+            pretend.call(
+                "http://server",
+                "api/v1/task/?task_id=task_id",
+                api_client.Methods.get,
+                headers={"Auth": "Token"},
+            ),
+            pretend.call(
+                "http://server",
+                "api/v1/task/?task_id=task_id",
+                api_client.Methods.get,
+                headers={"Auth": "Token"},
+            ),
+        ]
+
+    def test_task_status_unexpected_error(self):
+        api_client.request_server = pretend.call_recorder(
+            lambda *a, **kw: pretend.stub(status_code=500, text="body error")
+        )
+
+        with pytest.raises(api_client.click.ClickException) as err:
+            api_client.task_status(
+                "task_id", "http://server", {"Auth": "Token"}, "Test task: "
+            )
+
+        assert "Unexpected response body error" in str(err)
+
+    def test_task_status_failure(self):
+        fake_json = Mock()
+        fake_json.side_effect = [
+            {"data": {"state": "STARTED", "k": "v"}},
+            {"data": {"state": "RUNNING", "k": "v"}},
+            {"data": {"state": "FAILURE", "k": "v"}},
+        ]
+        api_client.request_server = pretend.call_recorder(
+            lambda *a, **kw: pretend.stub(
+                status_code=200,
+                json=fake_json,
+                text="{'data': {'state': 'FAILURE', 'k': 'v'}",
+            )
+        )
+
+        with pytest.raises(api_client.click.ClickException) as err:
+            api_client.task_status(
+                "task_id", "http://server", {"Auth": "Token"}, "Test task: "
+            )
+
+        assert "Failed: " in str(err)
+        assert api_client.request_server.calls == [
+            pretend.call(
+                "http://server",
+                "api/v1/task/?task_id=task_id",
+                api_client.Methods.get,
+                headers={"Auth": "Token"},
+            ),
+            pretend.call(
+                "http://server",
+                "api/v1/task/?task_id=task_id",
+                api_client.Methods.get,
+                headers={"Auth": "Token"},
+            ),
+            pretend.call(
+                "http://server",
+                "api/v1/task/?task_id=task_id",
+                api_client.Methods.get,
+                headers={"Auth": "Token"},
+            ),
+        ]
+
+    def test_task_status_without_state(self):
+        api_client.request_server = pretend.call_recorder(
+            lambda *a, **kw: pretend.stub(
+                status_code=200,
+                json=lambda: {"data": {"k": "v"}},
+                text="",
+            )
+        )
+
+        with pytest.raises(api_client.click.ClickException) as err:
+            api_client.task_status(
+                "task_id", "http://server", {"Auth": "Token"}, "Test task: "
+            )
+
+        assert "No state in data received " in str(err)
+        assert api_client.request_server.calls == [
+            pretend.call(
+                "http://server",
+                "api/v1/task/?task_id=task_id",
+                api_client.Methods.get,
+                headers={"Auth": "Token"},
+            ),
+        ]
+
+    def test_task_status_without_data(self):
+        api_client.request_server = pretend.call_recorder(
+            lambda *a, **kw: pretend.stub(
+                status_code=200,
+                json=lambda: {},
+                text="",
+            )
+        )
+
+        with pytest.raises(api_client.click.ClickException) as err:
+            api_client.task_status(
+                "task_id", "http://server", {"Auth": "Token"}, "Test task: "
+            )
+
+        assert "No data received " in str(err)
+        assert api_client.request_server.calls == [
+            pretend.call(
+                "http://server",
+                "api/v1/task/?task_id=task_id",
+                api_client.Methods.get,
+                headers={"Auth": "Token"},
+            ),
+        ]

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,8 @@ commands =
 
 [testenv:docs]
 deps = -r{toxinidir}/docs/requirements.txt
+allowlist_externals =
+    plantuml
 commands =
     plantuml -o ../source/_static/ -tpng docs/diagrams/*.puml
 	sphinx-apidoc -o  docs/source/devel/ repository_service_tuf


### PR DESCRIPTION
Implements the feature import target `rstuf admin import-targets`.

This feature gives the RSTUF administrator the functionality to import a large number of existent targets. It helps to roll out and deploy the RSTUF in existing repositories.

This feature is detailed and explained at these links
- https://github.com/vmware/repository-service-tuf/issues/188
- BDD Feature: https://github.com/vmware/repository-service-tuf/pull/218

Some changes in the ceremony was done to reuse in the code:

  - The `ceremony._check_server` was converted to `helpers.api_client.get_headers`
  - The `ceremony._bootstrap_state` was converted to `helpers.api_client.task_status`

Added 100% coverage to `helpsers.api_client`

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>