### PR TITLE
Fix ModuleNotFoundError: No module 'sqlalchemy'

### DIFF
--- a/repository_service_tuf/cli/admin/import_targets.py
+++ b/repository_service_tuf/cli/admin/import_targets.py
@@ -138,7 +138,9 @@ def import_targets(
     skip_publish_targets: bool,
 ):
     """
-    Import targets to RSTUF from exported CSV file.
+    Import targets to RSTUF from exported CSV file.\n
+    Note: sqlalchemy needs to be installed in order to use this command.\n
+    pip install repository-service-tuf[sqlalchemy,psycopg2]
     """
 
     # SQLAlchemy is an optional dependency and is required only for users who
@@ -148,7 +150,7 @@ def import_targets(
     except ModuleNotFoundError:
         raise ModuleNotFoundError(
             "SQLAlchemy is required by import-targets. "
-            "Use: 'pip install repository-service-tuf[sqlalchemy,psycopg2]'"
+            "pip install repository-service-tuf[sqlalchemy,psycopg2]"
         )
 
     settings = context.obj["settings"]

--- a/tests/unit/cli/admin/test_import_targets.py
+++ b/tests/unit/cli/admin/test_import_targets.py
@@ -423,7 +423,7 @@ class TestImportTargetsGroupCLI:
         assert result.exit_code == 1
         assert isinstance(result.exception, ModuleNotFoundError)
         exc_msg = result.exception.msg
-        assert "'pip install repository-service-tuf[sqlalchemy" in exc_msg
+        assert "pip install repository-service-tuf[sqlalchemy" in exc_msg
 
     def test_import_targets_bootstrap_check_failed(self, client, test_context):
         test_context["settings"].SERVER = "fake-server"


### PR DESCRIPTION
We have made "sqlalchemy" an optional dependency only for users who want to use the "import-targets" CLI command.
The reason for that is that we expect that this command will be rarely used.
For that reason, "sqlalchemy" is not installed by default, but we import all modules within the "repository_service_tuf/cli/admin" folder and given we imported "sqlalchemy" globally in import_targets module this resulted in an error "ModuleNotFoundError: No module 'sqlalchemy".

To resolve this issue we decided to import "sqlalchemy" inside the import_targets() function so that only when the "import-targets" command is used then you would see you will possibly get this error.

Closes https://github.com/vmware/repository-service-tuf/issues/245