### PR TITLE
Update CLI Guide with new user flow

### DIFF
--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -191,11 +191,11 @@ Step 1: Configure the Roles
 4. timestamp ``expiration``
 5. bins ``expiration``
 
-- ``expiration`` is the number of days in which the Metadata will expire
-- ``number of keys`` Metadata will have
-- ``threshold`` is the number of keys needed to sign the Metadata
+- ``expiration`` is the number of days in which the metadata will expire
+- ``number of keys`` the metadata will have
+- ``threshold`` is the number of keys needed to sign the metadata
 - ``base URL`` for the artifacts, example: http://www.example.com/download/
-- ``number of delegated hash bins`` is the number of hash bins roles, How many
+- ``number of delegated hash bins`` is the number of hash bin roles, How many
   delegated roles (``bins-X``) will it create?
 
 Step 2: Load the Online Key
@@ -233,9 +233,9 @@ Step 2: Load the Online Key
 Step 3: Load Root Keys
 ......................
 
-It is essential to define the Key Owners. There is a suggestion in the CLI.
+It is essential to define the key owners. There is a suggestion in the CLI.
 
-The owners will need to be present to share the key and use their password to
+The owners will need to be present to share their keys and use their passwords to
 load the keys.
 
 .. code::

--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -235,8 +235,8 @@ Step 3: Load Root Keys
 
 It is essential to define the key owners. There is a suggestion in the CLI.
 
-The owners will need to be present to share their keys and use their passwords to
-load the keys.
+The owners will need to be present to insert their keys and use their passwords
+to load the keys.
 
 .. code::
 
@@ -249,7 +249,7 @@ load the keys.
 
     The keys must have a password, and the file must be accessible.
 
-    Depending on the organization, each key has an owner, and each owner should insert the password
+    Depending on the organization, each key has an owner, and each owner should insert their password
     personally.
 
     Note: the ceremony process won't show any password or key content.
@@ -372,7 +372,7 @@ Using another computer with access to ``repository-service-tuf-api``
 
   1.  Get the generated ``payload.json`` (or the custom name you chose)
   2.  Install ``repository-service-tuf``
-  3.  Run ``rstuf admin ceremony -b [-u filename]``
+  3.  Run ``rstuf admin ceremony -b -u [-f filename]``
 
 Token (``token``)
 -----------------

--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -235,7 +235,7 @@ Step 3: Load Root Keys
 
 It is essential to define the key owners. There is a suggestion in the CLI.
 
-The owners will need to be present to insert their keys and use their passwords
+The owners will need to be present to insert their keys and passwords
 to load their keys.
 
 .. code::

--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -16,19 +16,20 @@ Using pip:
 .. code:: shell
 
     ❯ rstuf
-                                                                                                                                                 
-     Usage: rstuf [OPTIONS] COMMAND [ARGS]...                                                                                                  
-                                                                                                                                                 
-     Repository Service for TUF Command Line Interface (CLI).                                                                                        
-                                                                                                                                                 
-    ╭─ Options ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-    │  --config  -c  TEXT  Repository Service for TUF config file                                                                                   │
-    │  --help    -h        Show this message and exit.                                                                                          │
-    ╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
-    ╭─ Commands ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-    │  admin  Administrative Commands                                                                                                           │
-    ╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
-    
+
+    Usage: rstuf [OPTIONS] COMMAND [ARGS]...
+
+    Repository Service for TUF Command Line Interface (CLI).
+
+    ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+    │ --config   -c  TEXT  Repository Service for TUF config file                                                                      │
+    │ --version            Show the version and exit.                                                                                  │
+    │ --help     -h        Show this message and exit.                                                                                 │
+    ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+    ╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+    │ admin                      Administrative Commands                                                                               │
+    ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
 Administration (``admin``)
 ==========================
 
@@ -44,14 +45,15 @@ It executes administrative commands to the Repository Service for TUF.
 
     Administrative Commands
 
-    ╭─ Options ────────────────────────────────────────────────────────────────────────────╮
-    │  --help  -h    Show this message and exit.                                           │
-    ╰──────────────────────────────────────────────────────────────────────────────────────╯
-    ╭─ Commands ───────────────────────────────────────────────────────────────────────────╮
-    │  ceremony  Start a new Metadata Ceremony.                                            │
-    │  login     Login to Repository Service for TUF (API).                                            │
-    │  token     Token Management.                                                         │
-    ╰──────────────────────────────────────────────────────────────────────────────────────╯
+    ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+    │ --help  -h    Show this message and exit.                                                                                        │
+    ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+    ╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+    │ ceremony                        Start a new Metadata Ceremony.                                                                   │
+    │ import-targets                  Import targets to RSTUF from exported CSV file.                                                  │
+    │ login                           Login to Repository Service for TUF (API).                                                       │
+    │ token                           Token Management.                                                                                │
+    ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 
 
 Login to Server (``login``)
@@ -100,23 +102,20 @@ You can do the Ceremony offline. This means on a disconnected computer
 .. code:: shell
 
     ❯ rstuf admin ceremony --help
-                                                                                                                            
-    Usage: rstuf admin ceremony [OPTIONS]                                                                                  
-                                                                                                                            
-    Start a new Metadata Ceremony.                                                                                           
-                                                                                                                            
-    ╭─ Options ───────────────────────────────────────────────────────────────────────────────────────────────────────╮
-    │  --bootstrap  -b        Bootstrap a Repository Service for TUF using the Repository Metadata after Ceremony     │
-    │  --file       -f  TEXT  Generate specific JSON Payload compatible with Repository Service for TUF bootstrap     │
-                              after Ceremony                                                                          │
-    │                         [default: payload.json]                                                                 │
-    │  --upload     -u        Upload existent payload 'file'. Requires '-b/--bootstrap'. Optional '-f/--file' to use  │
-    │                         non default file.                                                                       │
-    │  --save       -s        Save a copy of the metadata locally. This option saves the metadata files (json) in the │
-    │                         'metadata' dir.                                                                         │
-    │                         [default: False]                                                                        │
-    │  --help       -h        Show this message and exit.                                                             │
-    ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+    Usage: rstuf admin ceremony [OPTIONS]
+
+    Start a new Metadata Ceremony.
+
+    ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+    │ --bootstrap  -b        Bootstrap a Repository Service for TUF using the Repository Metadata after Ceremony                       │
+    │ --file       -f  TEXT  Generate specific JSON Payload compatible with TUF Repository Service bootstrap after Ceremony            │
+    │                        [default: payload.json]                                                                                   │
+    │ --upload     -u        Upload existent payload 'file'. Requires '-b/--bootstrap'. Optional '-f/--file' to use non default file.  │
+    │ --save       -s        Save a copy of the metadata locally. This option saves the metadata files (json) in the 'metadata' folder │
+    │                        in the current directory.                                                                                 │
+    │ --help       -h        Show this message and exit.                                                                               │
+    ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 
 There are three steps in the Ceremony.
 
@@ -134,204 +133,233 @@ Step 1: Configure the Roles
     ❯ rstuf admin ceremony
 
     (...)
-    Do you want start the ceremony? [y/n]: y
-    ╔══════════════════════════════════════════════════════════════════════════════╗
-    ║                         STEP 1: Configure the Roles                          ║
-    ╚══════════════════════════════════════════════════════════════════════════════╝
+    Do you want to start the ceremony? [y/n]: y
+    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    ┃                         STEP 1: Configure the Roles                          ┃
+    ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-    The TUF roles support multiple keys and the threshold (quorum trust) defines
-    the minimal number of keys required to take actions using a specific Role.
+    The TUF root role supports multiple keys and the threshold (quorum of trust)
+    defines the minimal number of keys required to take actions using the root role.
 
-    Reference: TUF                                                                  
+    Reference: TUF Goals for PKI
 
-    What is the Metadata expiration for the root role?(Days) (365):
+    The TUF roles have an expiration, clients must not trust expired metadata.
+
+    Reference: TUF expires
+
+                                            root configuration
+
+    What is the metadata expiration for the root role?(Days) (365):
     What is the number of keys for the root role? (2):
     What is the key threshold for the root role signing? (1):
 
-    What is the Metadata expiration for the targets role?(Days) (365):
-    What is the number of keys for the targets role? (2):
-    What is the key threshold for the targets role signing? (1):
-    The role targets delegate trust for all target files to 'bin-n' roles based on file path hash prefixes,
-    a.k.a hash bin delegation. See TUF TAP 15: https://github.com/theupdateframework/taps/blob/master/tap15.md
-    You can also have a look at our example.
-    Show example [y/n] (y): y
+                                        targets configuration
 
-                                                Example:                                              
+    What is the metadata expiration for the targets role?(Days) (365):
 
-    The Organization Example (https://example.com) has all files downloaded /downloads path, meaning    
-    https://example.com/downloads/.                                                                     
 
-    Additionally, it has two sub-folders, productA and productB where the clients can find all files
-    (i.e.: productA-v1.0.tar, productB-v1.0.tar), for productB it even has a sub-folder, updates where
-    clients can find update files (i.e.: servicepack-1.tar, servicepack-2.tar).
-    The organization has decided to use 8 hash bins. Target files will be uniformly distributed over
-    8 bins whose names will be "1.bins-0.json", "1.bins-1.json", ... , "1.bins-7.json".
+    The target metadata file might contain a large number of target files.
+    That is why the targets role
+    delegates trust to the hash bin roles to reduce the metadata overhead for
+    clients.
 
-    Now imagine that the organization stores the following files:
-    - https://example.com/downloads/productA/productA-v1.0.tar
-    - https://example.com/downloads/productB/productB-v1.0.tar
-    - https://example.com/downloads/productB/updates/servicepack-1.tar
+    See: TUF Specification about succinct hash bin delegation.
+    Show example? [y/n] (y): y
 
-    As we said the targets will be uniformly distributed over the 8 bins no matter if they are
-    located in the same folder. In this example here is how they will be distributed:
-    - "1.bins-4.json" will be responsible for file productA/productA-v1.0.tar
-    - "1.bins-5.json" will be responsible for file productB/productB-v1.1.tar
-    - "1.bins-1.json" will be responsible for file productB/updates/servicepack-1.tar
+    Choose the number of delegated hash bin roles [2/4/8/16/32/64/128/256/512/1024/2048/4096/8192/16384] (256): 16
 
-    How many hash bins do you want for targets? (8):
+    What is the targets base URL? (i.e.: https://www.example.com/downloads/): http://www.example.com/downloads/
 
-    What is the Base URL (i.e.: https://www.example.com/downloads/): https://www.example.com/downloads/
+                                        snapshot configuration
 
-    What is the Metadata expiration for the snapshot role?(Days) (1):
-    What is the number of keys for the snapshot role? (1):
-    The threshold for snapshot is 1 (one) based on the number of keys (1).
+    What is the metadata expiration for the snapshot role?(Days) (1):
 
-    What is the Metadata expiration for timestamp role?(Days) (1):
-    What is the number of keys for timestamp role? (1):
-    The threshold for timestamp is 1 (one) based on the number of keys (1).
+                                        timestamp configuration
 
-    What is the Metadata expiration for the bins role?(Days) (1):
-    What is the number of keys for the bins role? (1):
-    The threshold for bins is 1 (one) based on the number of keys (1).
+    What is the metadata expiration for the timestamp role?(Days) (1):
+
+                                            bins configuration
+
+    What is the metadata expiration for the bins role?(Days) (1):
+
 
 
 1. root ``expiration``, ``number of keys``, and ``threshold``
-2. targets ``expiration``, ``number of keys``, ``threshold``, the ``base URL``
-   for the files (target files), and the ``number of hash bins``
-3. snapshot ``expiration``, ``number of keys``, and ``threshold``
-4. timestamp ``expiration``, ``number of keys``, and ``threshold``
-5. bins ``expiration``, ``number of keys``, and ``threshold``
+2. targets ``expiration``, the ``base URL`` for the files (target files), and the
+   ``number of delegated hash bins``
+3. snapshot ``expiration``
+4. timestamp ``expiration``
+5. bins ``expiration``
 
 - ``expiration`` is the number of days in which the Metadata will expire
 - ``number of keys`` Metadata will have
 - ``threshold`` is the number of keys needed to sign the Metadata
 - ``base URL`` for the artifacts, example: http://www.example.com/download/
-- ``number of hash bins`` is the number of hash bins between 1 and 32. How many
+- ``number of delegated hash bins`` is the number of hash bins roles, How many
   delegated roles (``bins-X``) will it create?
 
-Step 2: Loading the Keys
-........................
+Step 2: Load the Online Key
+...........................
+
+.. code::
+
+    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    ┃                                   STEP 2: Load the Online Key                                    ┃
+    ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+
+                                            The Online Key
+
+    The online key is the same one provided to the Repository Service for TUF Workers (RSTUF Worker).
+    This key is responsible for signing the snapshot, timestamp, targets, and delegated targets (hash
+    bin) roles.
+
+    The RSTUF Worker uses this key during the process of managing the metadata.
+
+    Note: the ceremony process won't show any password or key content.
+
+    Choose 1/1 ONLINE key type [ed25519/ecdsa/rsa] (ed25519):
+    Enter 1/1 the ONLINE`s private key path: tests/files/online.key
+    Enter 1/1 the ONLINE`s private key password:
+    ✅ Key 1/1 Verified
+
+    Step 3: Validate the information/settings
+    .........................................
+
+    After confirming all details, the initial payload for bootstrap will be
+    complete (without the offline keys).
+
+
+Step 3: Load Root Keys
+......................
 
 It is essential to define the Key Owners. There is a suggestion in the CLI.
 
 The owners will need to be present to share the key and use their password to
 load the keys.
 
-.. code:: shell
+.. code::
 
-    ╔══════════════════════════════════════════════════════════════════════════════════════════════════╗
-    ║                                     STEP 2: Load roles keys                                      ║
-    ╚══════════════════════════════════════════════════════════════════════════════════════════════════╝
+    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    ┃                                      STEP 3: Load Root Keys                                      ┃
+    ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-    The keys must have a password and the file must be accessible.
 
-    Depending on the Organization, each key has an owner. During the key loading process, it is
-    important that the owner of the key inserts the password.
+                                                Root Keys
 
-    The password or the key content is not shown on the screen.
+    The keys must have a password, and the file must be accessible.
 
-    Ready to start loading the keys? Passwords will be required for keys [y/n]: y
+    Depending on the organization, each key has an owner, and each owner should insert the password
+    personally.
 
-    Enter 1/2 the root`s Key path: tests/files/JanisJoplin.key
-    Enter 1/2 the root`s Key password:
+    Note: the ceremony process won't show any password or key content.
+
+    Choose 1/2 root key type [ed25519/ecdsa/rsa] (ed25519):
+    Enter 1/2 the root`s private key path: tests/files/JanisJoplin.key
+    Enter 1/2 the root`s private key password:
     ✅ Key 1/2 Verified
 
-    Enter 2/2 the root`s Key path: tests/files/JimiHendrix.key
-    Enter 2/2 the root`s Key password:
+    Choose 2/2 root key type [ed25519/ecdsa/rsa] (ed25519):
+    Enter 2/2 the root`s private key path: tests/files/JimiHendrix.key
+    Enter 2/2 the root`s private key password:
     ✅ Key 2/2 Verified
 
-    Enter 1/2 the targets`s Key path: tests/files/KurtCobain.key
-    Enter 1/2 the targets`s Key password:
-    ✅ Key 1/2 Verified
+Step 3: Validate Configuration
+..............................
 
-    Enter 2/2 the targets`s Key path: tests/files/ChrisCornel.key
-    Enter 2/2 the targets`s Key password:
-    ✅ Key 2/2 Verified
+.. code::
 
-    Enter 1/1 the snapshot`s Key path: tests/files/snapshot1.key
-    Enter 1/1 the snapshot`s Key password:
-    ✅ Key 1/1 Verified
+    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    ┃                                  STEP 4: Validate Configuration                                  ┃
+    ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-    Enter 1/1 the timestamp`s Key path: tests/files/timestamp1.key
-    Enter 1/1 the timestamp`s Key password:
-    ✅ Key 1/1 Verified
-
-    Enter 1/1 the bins`s Key path: tests/files/bins1.key
-    Enter 1/1 the bins`s Key password:
-    ✅ Key 1/1 Verified
+    The information below is the configuration done in the previous steps. Check the number of keys, the
+    threshold/quorum, and the key details.
 
 
-Step 3: Validate the information/settings
-.........................................
+    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    ┃ ONLINE KEY SUMMARY                                                                                                ┃
+    ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+    │                          ╷        ╷          ╷                                                                    │
+    │                     path │  type  │ verified │                                id                                  │
+    │ ╶────────────────────────┼────────┼──────────┼──────────────────────────────────────────────────────────────────╴ │
+    │   tests/files/online.key │ Online │    ✅    │ f7a6872f297634219a80141caa2ec9ae8802098b07b67963272603e36cc19fd8   │
+    │                          ╵        ╵          ╵                                                                    │
+    └───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 
-After confirming all details, the initial payload for bootstrap will be
-complete (without the offline keys).
+    Is the online key configuration correct? [y/n]: y
 
-.. code:: shell
 
-    ╔══════════════════════════════════════════════════════════════════════════════════════════════════╗
-    ║                                  STEP 3: Validate configuration                                  ║
-    ╚══════════════════════════════════════════════════════════════════════════════════════════════════╝
+    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    ┃ ROLE SUMMARY              ┃                                                 KEYS                                                 ┃
+    ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+    │                           │                               ╷         ╷          ╷                                                 │
+    │ Role: root                │                          path │  type   │ verified │                      id                         │
+    │ Number of Keys: 2         │ ╶─────────────────────────────┼─────────┼──────────┼───────────────────────────────────────────────╴ │
+    │ Threshold: 1              │   tests/files/JanisJoplin.key │ Offline │    ✅    │ 1cebe343e35f0213f6136758e6c3a8f8e1f9eeb7e47a…   │
+    │ Role Expiration: 365 days │   tests/files/JimiHendrix.key │ Offline │    ✅    │ 800dfb5a1982b82b7893e58035e19f414f553fc08cbb…   │
+    │                           │                               ╵         ╵          ╵                                                 │
+    └───────────────────────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────┘
 
-    The information below is the configuration done in the preview steps. Check the number of keys, the
-    threshold/quorum and type of key.
-    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-    ┃       ROLE SUMMARY        ┃                                 KEYS                                 ┃
-    ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-    │        Role: root         │                   ╷                                     ╷            │
-    │     Number of Keys: 2     │              path │                 id                  │ verified   │
-    │       Threshold: 1        │ ╶─────────────────┼─────────────────────────────────────┼──────────╴ │
-    │    Keys Type: offline     │   JanisJoplin.key │ 1cebe343e35f0213f6136758e6c3a8f8e1… │    ✅      │
-    │ Role Expiration: 365 days │   JimiHendrix.key │ 800dfb5a1982b82b7893e58035e19f414f… │    ✅      │
-    │                           │                   ╵                                     ╵            │
-    └───────────────────────────┴──────────────────────────────────────────────────────────────────────┘
-    Configuration correct for root? [y/n]: y
-    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-    ┃              ROLE SUMMARY               ┃                          KEYS                          ┃
-    ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-    │              Role: targets              │                   ╷                       ╷            │
-    │            Number of Keys: 2            │              path │          id           │ verified   │
-    │              Threshold: 1               │ ╶─────────────────┼───────────────────────┼──────────╴ │
-    │           Keys Type: offline            │    KurtCobain.key │ 208fc4139cf7482abbe8… │    ✅      │
-    │        Role Expiration: 365 days        │   ChrisCornel.key │ c2e9ee4a292e5d08bc0d… │    ✅      │
-    │                                         │                   ╵                       ╵            │
-    │                                         │                                                        │
-    │                                         │                                                        │
-    │               DELEGATIONS               │                                                        │
-    │             targets -> bins             │                                                        │
-    │              Number bins: 8             │                                                                        │
-    └─────────────────────────────────────────┴────────────────────────────────────────────────────────┘
-    Configuration correct for targets? [y/n]: y
-    ┏━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-    ┃      ROLE SUMMARY       ┃                                  KEYS                                  ┃
-    ┡━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-    │     Role: snapshot      │                 ╷                                         ╷            │
-    │    Number of Keys: 1    │            path │                   id                    │ verified   │
-    │      Threshold: 1       │ ╶───────────────┼─────────────────────────────────────────┼──────────╴ │
-    │    Keys Type: online    │   snapshot1.key │ 139c406ac6150598fb9f7cafd1463bc07e0318… │    ✅      │
-    │ Role Expiration: 1 days │                 ╵                                         ╵            │
-    └─────────────────────────┴────────────────────────────────────────────────────────────────────────┘
-    Configuration correct for snapshot? [y/n]: y
-    ┏━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-    ┃      ROLE SUMMARY       ┃                                  KEYS                                  ┃
-    ┡━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-    │     Role: timestamp     │                  ╷                                        ╷            │
-    │    Number of Keys: 1    │             path │                   id                   │ verified   │
-    │      Threshold: 1       │ ╶────────────────┼────────────────────────────────────────┼──────────╴ │
-    │    Keys Type: online    │   timestamp1.key │ 19f5992640ab71f49fb64d5b5d198ee0115c3… │    ✅      │
-    │ Role Expiration: 1 days │                  ╵                                        ╵            │
-    └─────────────────────────┴────────────────────────────────────────────────────────────────────────┘
-    Configuration correct for timestamp? [y/n]: y
-    ┏━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-    ┃      ROLE SUMMARY       ┃                                  KEYS                                  ┃
-    ┡━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-    │       Role: bins        │             ╷                                             ╷            │
-    │    Number of Keys: 1    │        path │                     id                      │ verified   │
-    │      Threshold: 1       │ ╶───────────┼─────────────────────────────────────────────┼──────────╴ │
-    │    Keys Type: online    │   bins1.key │ 9b2a880bd470e8373e24efb0dc54df3909e180e445… │    ✅       │
-    │ Role Expiration: 1 days │             ╵                                             ╵            │
-    └─────────────────────────┴────────────────────────────────────────────────────────────────────────┘
-    Configuration correct for bins? [y/n]: y
+    Is the root configuration correct? [y/n]: y
+
+
+    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    ┃ ROLE SUMMARY                                ┃                                        KEYS                                        ┃
+    ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+    │                                             │          ╷          ╷                                                              │
+    │ Role: targets                               │    type  │ verified │                             id                               │
+    │ Role Expiration: 365 days                   │ ╶────────┼──────────┼────────────────────────────────────────────────────────────╴ │
+    │                                             │   Online │    ✅    │ f7a6872f297634219a80141caa2ec9ae8802098b07b67963272603e36…   │
+    │                                             │          ╵          ╵                                                              │
+    │                                             │                                                                                    │
+    │ Base URL: http://www.example.com/downloads/ │                                                                                    │
+    │                                             │                                                                                    │
+    │ DELEGATIONS                                 │                                                                                    │
+    │ targets -> bins                             │                                                                                    │
+    │ Number of bins: 16                          │                                                                                    │
+    └─────────────────────────────────────────────┴────────────────────────────────────────────────────────────────────────────────────┘
+
+    Is the targets configuration correct? [y/n]: y
+
+
+    ┏━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    ┃ ROLE SUMMARY            ┃                                           KEYS                                           ┃
+    ┡━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+    │                         │          ╷          ╷                                                                    │
+    │ Role: snapshot          │    type  │ verified │                                id                                  │
+    │ Role Expiration: 1 days │ ╶────────┼──────────┼──────────────────────────────────────────────────────────────────╴ │
+    │                         │   Online │    ✅    │ f7a6872f297634219a80141caa2ec9ae8802098b07b67963272603e36cc19fd8   │
+    │                         │          ╵          ╵                                                                    │
+    └─────────────────────────┴──────────────────────────────────────────────────────────────────────────────────────────┘
+
+    Is the snapshot configuration correct? [y/n]: y
+
+
+    ┏━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    ┃ ROLE SUMMARY            ┃                                           KEYS                                           ┃
+    ┡━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+    │                         │          ╷          ╷                                                                    │
+    │ Role: timestamp         │    type  │ verified │                                id                                  │
+    │ Role Expiration: 1 days │ ╶────────┼──────────┼──────────────────────────────────────────────────────────────────╴ │
+    │                         │   Online │    ✅    │ f7a6872f297634219a80141caa2ec9ae8802098b07b67963272603e36cc19fd8   │
+    │                         │          ╵          ╵                                                                    │
+    └─────────────────────────┴──────────────────────────────────────────────────────────────────────────────────────────┘
+
+    Is the timestamp configuration correct? [y/n]: y
+
+
+    ┏━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    ┃ ROLE SUMMARY            ┃                                           KEYS                                           ┃
+    ┡━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+    │                         │          ╷          ╷                                                                    │
+    │ Role: bins              │    type  │ verified │                                id                                  │
+    │ Role Expiration: 1 days │ ╶────────┼──────────┼──────────────────────────────────────────────────────────────────╴ │
+    │                         │   Online │    ✅    │ f7a6872f297634219a80141caa2ec9ae8802098b07b67963272603e36cc19fd8   │
+    │                         │          ╵          ╵                                                                    │
+    └─────────────────────────┴──────────────────────────────────────────────────────────────────────────────────────────┘
+
+    Is the bins configuration correct? [y/n]: y
 
 Finishing
 .........
@@ -341,9 +369,10 @@ If you choose ``-b/--bootstrap`` it will automatically send the bootstrap to
 
 If you did the ceremony in a disconnected computer:
 Using another computer with access to ``repository-service-tuf-api``
-1.  Get the generated ``payload.json`` (or the custom name you chose)
-2.  Install ``repository-service-tuf``
-3.  Run ``rstuf admin ceremony -b [-u filename]``
+
+  1.  Get the generated ``payload.json`` (or the custom name you chose)
+  2.  Install ``repository-service-tuf``
+  3.  Run ``rstuf admin ceremony -b [-u filename]``
 
 Token (``token``)
 -----------------
@@ -352,14 +381,14 @@ Token (``token``)
 
 Token Management
 
-.. code:: shell
+.. code::
 
     ❯ rstuf admin token
-                                                                                                                            
-    Usage: rstuf admin token [OPTIONS] COMMAND [ARGS]...                                                                   
-                                                                                                                            
-    Token Management.                                                                                                        
-                                                                                                                            
+
+    Usage: rstuf admin token [OPTIONS] COMMAND [ARGS]...
+
+    Token Management.
+
     ╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
     │  --help  -h    Show this message and exit.                                                                             │
     ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
@@ -375,18 +404,18 @@ Token Management
 
 Generate tokens to use in integrations.
 
-.. code:: shell
+.. code::
 
     ❯ rstuf admin token generate -h
-                                                                                                        
-    Usage: rstuf admin token generate [OPTIONS]                                                      
-                                                                                                        
+
+    Usage: rstuf admin token generate [OPTIONS]
+
     Generate a new token.
-                                                                                                        
+
     ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
     │     --expires  -e  INTEGER  Expires in hours. Default: 24 [default: 24]                          │
     │  *  --scope    -s  TEXT     Scope to grant. Multiple is accepted. Ex: -s write:targets -s        │
-    │                             read:settings                                                         │
+    │                             read:settings                                                        │
     │                             [required]                                                           │
     │     --help     -h           Show this message and exit.                                          │
     ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
@@ -417,11 +446,11 @@ Show token detailed information.
 .. code:: shell
 
     ❯ rstuf admin token inspect -h
-                                                                                                                            
-    Usage: rstuf admin token inspect [OPTIONS] TOKEN                                                                       
-                                                                                                                            
-    Show token information details.                                                                                          
-                                                                                                                            
+
+    Usage: rstuf admin token inspect [OPTIONS] TOKEN
+
+    Show token information details.
+
     ╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
     │  --help  -h    Show this message and exit.                                                                             │
     ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -112,7 +112,7 @@ You can do the Ceremony offline. This means on a disconnected computer
     │ --file       -f  TEXT  Generate specific JSON Payload compatible with TUF Repository Service bootstrap after Ceremony            │
     │                        [default: payload.json]                                                                                   │
     │ --upload     -u        Upload existent payload 'file'. Requires '-b/--bootstrap'. Optional '-f/--file' to use non default file.  │
-    │ --save       -s        Save a copy of the metadata locally. This option saves the metadata files (json) in the 'metadata' folder │
+    │ --save       -s        Save a copy of the metadata locally. This option saves the JSON metadata files in the 'metadata' folder   │
     │                        in the current directory.                                                                                 │
     │ --help       -h        Show this message and exit.                                                                               │
     ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
@@ -236,7 +236,7 @@ Step 3: Load Root Keys
 It is essential to define the key owners. There is a suggestion in the CLI.
 
 The owners will need to be present to insert their keys and use their passwords
-to load the keys.
+to load their keys.
 
 .. code::
 

--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -117,7 +117,7 @@ You can do the Ceremony offline. This means on a disconnected computer
     │ --help       -h        Show this message and exit.                                                                               │
     ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 
-There are three steps in the Ceremony.
+There are four steps in the ceremony.
 
 .. note::
 
@@ -264,7 +264,7 @@ to load their keys.
     Enter 2/2 the root`s private key password:
     ✅ Key 2/2 Verified
 
-Step 3: Validate Configuration
+Step 4: Validate Configuration
 ..............................
 
 .. code::

--- a/repository_service_tuf/cli/admin/ceremony.py
+++ b/repository_service_tuf/cli/admin/ceremony.py
@@ -178,7 +178,7 @@ STEP_3 = """
 The keys must have a password, and the file must be accessible.
 
 Depending on the organization, each key has an owner, and each owner should
-insert the password personally.
+insert their password personally.
 
 Note: the ceremony process won't show any password or key content.
 """
@@ -713,8 +713,8 @@ def _run_ceremony_steps(save: bool) -> Dict[str, Any]:
     "-s",
     "--save",
     help=(
-        "Save a copy of the metadata locally. This option saves the metadata "
-        "files (json) in the 'metadata' folder in the current directory."
+        "Save a copy of the metadata locally. This option saves the JSON "
+        "metadata files in the 'metadata' folder in the current directory."
     ),
     default=False,
     show_default=True,


### PR DESCRIPTION
The CLI Guide is outdated after the new flow for adding the single online key.

This commit updates it.

Basically, it is a new copy from the CLI interface.
In some of `.. code::` the `shell` statement was removed due to incompatibility (special characters in the interface)

Closes #223