### PR TITLE
Add simple cli key generator

### DIFF
--- a/docs/source/devel/index.rst
+++ b/docs/source/devel/index.rst
@@ -17,5 +17,6 @@ Component level
    repository_service_tuf
    repository_service_tuf.cli
    repository_service_tuf.cli.admin
+   repository_service_tuf.cli.key
    repository_service_tuf.helpers
    modules

--- a/docs/source/devel/repository_service_tuf.cli.key.rst
+++ b/docs/source/devel/repository_service_tuf.cli.key.rst
@@ -1,0 +1,21 @@
+repository\_service\_tuf.cli.key package
+========================================
+
+Submodules
+----------
+
+repository\_service\_tuf.cli.key.generate\_key module
+-----------------------------------------------------
+
+.. automodule:: repository_service_tuf.cli.key.generate_key
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: repository_service_tuf.cli.key
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -1,3 +1,4 @@
+
 ==============================
 Repository Service for TUF CLI
 ==============================
@@ -28,6 +29,7 @@ Using pip:
     ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
     ╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
     │ admin                      Administrative Commands                                                                               │
+    │ key                        Cryptographic Key Commands                                                                            │
     ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 
 Administration (``admin``)
@@ -542,3 +544,57 @@ See the below CSV file example:
     Import status: task STARTED
     Import status: task SUCCESS
     Import status: Finished.
+
+
+Key Management (``key``)
+========================
+
+.. rstuf-cli-key
+
+It executes commands related to cryptographic key management and may be used
+for managing keys in the Repository Service for TUF.
+
+.. code:: shell
+
+    ❯ rstuf key
+
+    Usage: rstuf key [OPTIONS] COMMAND [ARGS]...
+
+    Cryptographic Key Commands
+
+    ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+    │ --help  -h    Show this message and exit.                                                                                        │
+    ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+    ╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+    │ generate                        Generate cryptographic keys using the `securesystemslib` library                                 │
+    ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+Key Generation (``generate``)
+-----------------------------
+
+.. rstuf-cli-key-generate
+
+This command will generate cryptographic keys using the ``securesystemslib`` library.
+The user is requested to provide:
+
+1. the key type, from the supported list of encryption algorithms
+
+2. the key's filename, whose path will be the current working directory
+
+3. a password, to encrypt the private key file
+
+After the above procedure, two files, the private and public key
+(e.g., ``id_ed25519`` and ``id_ed25519.pub``), will be generated in the current
+working directory.
+
+The generated keys may be used in the Repository Service for TUF Ceremony
+process, for the online key or the TUF roles' keys (``root``, ``targets``, etc. keys).
+
+.. code::
+
+    ❯ rstuf key generate
+
+    Choose key type [ed25519/ecdsa/rsa] (ed25519): ed25519
+    Enter the key's filename: (id_ed25519): id_ed25519
+    Enter password to encrypt private key file 'id_ed25519':
+    Confirm:

--- a/repository_service_tuf/cli/admin/ceremony.py
+++ b/repository_service_tuf/cli/admin/ceremony.py
@@ -18,14 +18,12 @@ from securesystemslib.exceptions import (  # type: ignore
     StorageError,
 )
 from securesystemslib.interface import (  # type: ignore
-    KEY_TYPE_ECDSA,
-    KEY_TYPE_ED25519,
-    KEY_TYPE_RSA,
     import_privatekey_from_file,
 )
 
 from repository_service_tuf.cli import click
 from repository_service_tuf.cli.admin import admin
+from repository_service_tuf.constants import KeyType
 from repository_service_tuf.helpers.api_client import (
     URL,
     LazySettings,
@@ -443,8 +441,8 @@ def _configure_keys(
     while key_count <= number_of_keys:
         key_type = prompt.Prompt.ask(
             f"\nChoose {key_count}/{number_of_keys} [cyan]{role}[/] key type",
-            choices=[KEY_TYPE_ED25519, KEY_TYPE_ECDSA, KEY_TYPE_RSA],
-            default=KEY_TYPE_ED25519,
+            choices=KeyType.get_all_members(),
+            default=KeyType.KEY_TYPE_ED25519.value,
         )
         filepath = prompt.Prompt.ask(
             f"Enter {key_count}/{number_of_keys} the "

--- a/repository_service_tuf/cli/key/__init__.py
+++ b/repository_service_tuf/cli/key/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2022-2023 VMware Inc
+#
+# SPDX-License-Identifier: MIT
+
+from repository_service_tuf.cli import rstuf
+
+
+@rstuf.group()
+def key():
+    """Cryptographic Key Commands"""

--- a/repository_service_tuf/cli/key/generate_key.py
+++ b/repository_service_tuf/cli/key/generate_key.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: 2022-2023 VMware Inc
+#
+# SPDX-License-Identifier: MIT
+import os
+
+from rich import prompt
+from rich.console import Console  # type: ignore
+from securesystemslib.interface import (  # type: ignore
+    _generate_and_write_ecdsa_keypair,
+    _generate_and_write_ed25519_keypair,
+    _generate_and_write_rsa_keypair,
+    _get_key_file_encryption_password,
+    get_password,
+)
+
+from repository_service_tuf.cli import click
+from repository_service_tuf.cli.key import key
+from repository_service_tuf.constants import KeyType
+
+console = Console()
+
+
+def _verify_password(filename: str) -> str:
+    """
+    Prompt user for password, verify and return it using `securesystemslib`
+    conventions for password management
+    """
+
+    while True:
+        password: str = get_password(
+            f"Enter password to encrypt private key file '{str(filename)}': ",
+            confirm=True,
+        )
+
+        # checks that the password is a string and 1 or more characters long
+        try:
+            return _get_key_file_encryption_password(password, False, filename)
+        except ValueError as err:
+            click.echo(err)
+
+
+@key.command()
+def generate() -> None:
+    """Generate cryptographic keys using the `securesystemslib` library"""
+
+    key_type: str = prompt.Prompt.ask(
+        "\nChoose key type",
+        choices=KeyType.get_all_members(),
+        default=KeyType.KEY_TYPE_ED25519.value,
+    )
+
+    filename: str = prompt.Prompt.ask(
+        "Enter the key's [green]filename[/]:",
+        default=f"id_{key_type}",
+    )
+    if os.path.isfile(filename) is True:
+        overwrite = prompt.Confirm.ask(
+            f"Do you want to [red]overwrite[/] the existing '{filename}' file?"
+        )
+        if overwrite is False:
+            raise click.ClickException("Key creation aborted.")
+
+    password = _verify_password(filename)
+
+    match key_type:
+        case KeyType.KEY_TYPE_ED25519.value:
+            _generate_and_write_ed25519_keypair(
+                password=password, filepath=filename
+            )
+
+        case KeyType.KEY_TYPE_ECDSA.value:
+            _generate_and_write_ecdsa_keypair(
+                password=password, filepath=filename
+            )
+
+        case KeyType.KEY_TYPE_RSA.value:
+            _generate_and_write_rsa_keypair(
+                password=password, filepath=filename
+            )
+
+        case _:
+            raise ValueError(f"Key type `{key_type}` is not supported!")

--- a/repository_service_tuf/constants.py
+++ b/repository_service_tuf/constants.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2022-2023 VMware Inc
+#
+# SPDX-License-Identifier: MIT
+
+from enum import Enum
+from typing import List
+
+from securesystemslib.interface import (  # type: ignore
+    KEY_TYPE_ECDSA,
+    KEY_TYPE_ED25519,
+    KEY_TYPE_RSA,
+)
+
+
+class KeyType(str, Enum):
+    """Represents the key types from `securesystemslib` that we support"""
+
+    KEY_TYPE_ED25519 = KEY_TYPE_ED25519
+    KEY_TYPE_ECDSA = KEY_TYPE_ECDSA
+    KEY_TYPE_RSA = KEY_TYPE_RSA
+
+    @classmethod
+    def get_all_members(cls) -> List[str]:
+        return [e.value for e in cls]

--- a/tests/unit/cli/admin/test_ceremony.py
+++ b/tests/unit/cli/admin/test_ceremony.py
@@ -6,6 +6,7 @@ import pretend  # type: ignore
 import pytest
 
 from repository_service_tuf.cli.admin import ceremony
+from repository_service_tuf.constants import KeyType
 
 
 class TestCeremonyFunctions:
@@ -36,10 +37,12 @@ class TestCeremonyFunctions:
             pretend.call_recorder(lambda *a: {"keyid": "ema"}),
         )
 
-        result = ceremony._load_key("/p/key", ceremony.KEY_TYPE_ED25519, "pwd")
+        result = ceremony._load_key(
+            "/p/key", KeyType.KEY_TYPE_ED25519.value, "pwd"
+        )
         assert result == ceremony.RSTUFKey({"keyid": "ema"}, "/p/key", None)
         assert ceremony.import_privatekey_from_file.calls == [
-            pretend.call("/p/key", ceremony.KEY_TYPE_ED25519, "pwd")
+            pretend.call("/p/key", KeyType.KEY_TYPE_ED25519.value, "pwd")
         ]
 
     def test__load_key_CryptoError(self, monkeypatch):
@@ -49,7 +52,9 @@ class TestCeremonyFunctions:
             pretend.raiser(ceremony.CryptoError("wrong password")),
         )
 
-        result = ceremony._load_key("/p/key", ceremony.KEY_TYPE_ED25519, "pwd")
+        result = ceremony._load_key(
+            "/p/key", KeyType.KEY_TYPE_ED25519.value, "pwd"
+        )
         assert result == ceremony.RSTUFKey(
             {},
             None,
@@ -65,7 +70,9 @@ class TestCeremonyFunctions:
             "import_privatekey_from_file",
             pretend.raiser(OSError("permission denied")),
         )
-        result = ceremony._load_key("/p/key", ceremony.KEY_TYPE_ED25519, "pwd")
+        result = ceremony._load_key(
+            "/p/key", KeyType.KEY_TYPE_ED25519.value, "pwd"
+        )
         assert result == ceremony.RSTUFKey(
             {}, None, error=":cross_mark: [red]Failed[/]: permission denied"
         )

--- a/tests/unit/cli/key/test_generate_key.py
+++ b/tests/unit/cli/key/test_generate_key.py
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: 2022-2023 VMware Inc
+#
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+from unittest import mock
+
+import pretend
+import pytest
+from securesystemslib.exceptions import FormatError  # type: ignore
+
+from repository_service_tuf.cli.key import generate_key
+from repository_service_tuf.cli.key.generate_key import _verify_password
+from repository_service_tuf.constants import KeyType
+
+
+class TestGenerateInteraction:
+    """Test the Key Generate Interaction"""
+
+    @pytest.mark.parametrize("key_type", KeyType.get_all_members() + ["\n"])
+    def test_generate_key_types(self, key_type: str, client) -> None:
+        """
+        Test that all `KeyType` enum members are possible input choices.
+
+        Note: We also test that a default ('\n') key type value is set
+        """
+
+        test_result = client.invoke(
+            generate_key.generate,
+            input=key_type,  # Choose key type [ed25519/ecdsa/rsa] (ed25519)
+        )
+
+        assert (
+            "Choose key type [ed25519/ecdsa/rsa] (ed25519):"
+        ) in test_result.output
+
+        assert (
+            "Please select one of the available options"
+            not in test_result.output
+        )
+
+        assert test_result.exit_code == 1
+
+    @pytest.mark.parametrize("filename", ["\n", "test-filename"])
+    def test_generate(self, filename: str, client, monkeypatch) -> None:
+        """
+        Test all the steps in the `generate` sub-command work as expected
+
+        Note: We also test that a default ('\n') filename value is set
+        """
+
+        try:
+            key_type = "rsa"
+            password = "test-password"
+            inputs = [
+                key_type,  # Choose key type [ed25519/ecdsa/rsa] (ed25519)
+                filename,  # Enter the keys' filename ...
+            ]
+
+            generate_key._verify_password = pretend.call_recorder(
+                lambda a: password
+            )
+
+            test_result = client.invoke(
+                generate_key.generate,
+                input="\n".join(inputs),
+            )
+
+            # the default option for the filename
+            if filename == "\n":
+                filepath = f"id_{key_type}"
+            else:
+                filepath = filename
+
+            assert generate_key._verify_password.calls == [  # type: ignore
+                pretend.call(filepath)
+            ]
+
+            # password not shown in output
+            assert password not in test_result.output
+
+            assert test_result.exit_code == 0
+
+        finally:
+            # remove the generated keys
+            Path(filepath).unlink(missing_ok=True)
+            Path(filepath + ".pub").unlink(missing_ok=True)
+
+    def test_generate_file_overwrite(self, client, monkeypatch) -> None:
+        """Test the 'overwrite file' prompt"""
+
+        key_type = "rsa"
+        password = "test-password"
+        filename = "test-filename"
+        inputs = [
+            key_type,  # Choose key type [ed25519/ecdsa/rsa] (ed25519)
+            filename,  # Enter the keys' filename ...
+            "n",  # Do you want to overwrite the existing 'test-filename' file?
+        ]
+
+        generate_key.os.path.isfile = pretend.call_recorder(
+            lambda *a, **kw: True
+        )
+
+        generate_key._verify_password = pretend.call_recorder(
+            lambda a: password
+        )
+
+        test_result = client.invoke(
+            generate_key.generate,
+            input="\n".join(inputs),
+        )
+
+        assert generate_key.os.path.isfile.calls == [pretend.call(filename)]  # type: ignore # noqa: E501
+
+        # verify `_verify_password` is never called
+        assert generate_key._verify_password.calls == []  # type: ignore
+
+        assert (
+            f"Do you want to overwrite the existing '{filename}' file?"
+            in test_result.output
+        )
+
+        assert "Key creation aborted." in test_result.output
+
+        # password not shown in output
+        assert password not in test_result.output
+
+        assert test_result.exit_code == 1
+
+
+class TestGenerateFunctions:
+    """Test the Key Generate Functions"""
+
+    @mock.patch("repository_service_tuf.cli.key.generate_key.get_password")
+    def test__verify_password(self, mock_password, capsys) -> None:
+        """
+        Test that the password is verified correctly
+        """
+
+        mock_password.return_value = "test-password"
+
+        _verify_password("test-filename")
+
+        captured = capsys.readouterr()
+
+        assert (
+            "encryption password must be 1 or more characters long\n"
+            not in captured.out
+        )
+
+    @mock.patch("repository_service_tuf.cli.key.generate_key.get_password")
+    def test__verify_password_empty_password(
+        self, mock_password, capsys
+    ) -> None:
+        """
+        Test that the password is verified correctly if it is empty at the
+        first attempt
+        """
+
+        mock_password.side_effect = ["", "test-password"]
+
+        _verify_password("test-filename")
+
+        captured = capsys.readouterr()
+
+        assert captured.out == (
+            "encryption password must be 1 or more characters long\n"
+        )
+
+    @mock.patch("repository_service_tuf.cli.key.generate_key.get_password")
+    def test__verify_password_not_string_password(
+        self, mock_password, capsys
+    ) -> None:
+        """
+        Test that the password is verified correctly if it is a number at the
+        first attempt
+        """
+
+        password = 123
+        mock_password.side_effect = [password, "test-password"]
+
+        with pytest.raises(FormatError):
+            _verify_password("test-filename")


### PR DESCRIPTION
This newly added command is used to generate cryptographic keys using the `securesystemslib` library.

Notes:
- We probably still need to create a documentation task for this new CLI command

Closes #219