### PR TITLE
Add `--save` back to default values test

### DIFF
--- a/tests/unit/cli/admin/test_ceremony.py
+++ b/tests/unit/cli/admin/test_ceremony.py
@@ -368,6 +368,7 @@ class TestCeremonyInteraction:
 
         test_result = client.invoke(
             ceremony.ceremony,
+            "--save",
             input="\n".join(
                 input_step1 + input_step2 + input_step3 + input_step4
             ),


### PR DESCRIPTION
We use this specific test in the Functional Tests.

During the roles-simplification we removed the parameter `--save` (to save the metadata) by mistake.

This commit adds back the parameter to the specific test.