### PR TITLE
fix the documentation anchor position

### DIFF
--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -32,10 +32,10 @@ Using pip:
     │ key                        Cryptographic Key Commands                                                                            │
     ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 
+.. rstuf-cli-admin
+
 Administration (``admin``)
 ==========================
-
-.. rstuf-cli-admin
 
 It executes administrative commands to the Repository Service for TUF.
 
@@ -57,11 +57,10 @@ It executes administrative commands to the Repository Service for TUF.
     │ token                           Token Management.                                                                                │
     ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 
+.. rstuf-cli-admin-login
 
 Login to Server (``login``)
 ---------------------------
-
-.. rstuf-cli-admin-login
 
 This command will log in to Repository Service for TUF and give you a token to run other commands
 such as Ceremony, Token Generation, etc.
@@ -86,11 +85,10 @@ such as Ceremony, Token Generation, etc.
 
     Login successful.
 
+.. rstuf-cli-admin-ceremony
 
 Ceremony (``ceremony``)
 -----------------------
-
-.. rstuf-cli-admin-ceremony
 
 The Repository Service for TUF Metadata uses the following Roles: ``root``, ``timestamp``,
 ``snapshot``, ``targets``, and ``bins`` to build the Repository
@@ -376,10 +374,11 @@ Using another computer with access to ``repository-service-tuf-api``
   2.  Install ``repository-service-tuf``
   3.  Run ``rstuf admin ceremony -b -u [-f filename]``
 
-Token (``token``)
------------------
 
 .. rstuf-cli-admin-token
+
+Token (``token``)
+-----------------
 
 Token Management
 
@@ -399,10 +398,10 @@ Token Management
     │  inspect   Show token information details.                                                                             │
     ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 
+.. rstuf-cli-admin-token-generate
+
 ``generate``
 ............
-
-.. rstuf-cli-admin-token-generate
 
 Generate tokens to use in integrations.
 
@@ -438,10 +437,10 @@ Example of usage:
 This token can be used with GitHub Secrets, Jenkins Secrets, CircleCI, shell
 script, etc
 
+.. rstuf-cli-admin-token-inspect
+
 ``inspect``
 ...........
-
-.. rstuf-cli-admin-token-inspect
 
 Show token detailed information.
 
@@ -470,10 +469,10 @@ Show token detailed information.
     }
 
 
+.. rstuf-cli-admin-import-targets
+
 Import Targets (``import-targets``)
 -----------------------------------
-
-.. rstuf-cli-admin-import-targets
 
 This feature imports a large number of targets directly to RSTUF Database.
 RSTUF doesn't recommend using this feature for regular flow, but in case you're
@@ -546,10 +545,10 @@ See the below CSV file example:
     Import status: Finished.
 
 
+.. rstuf-cli-key
+
 Key Management (``key``)
 ========================
-
-.. rstuf-cli-key
 
 It executes commands related to cryptographic key management and may be used
 for managing keys in the Repository Service for TUF.
@@ -569,10 +568,11 @@ for managing keys in the Repository Service for TUF.
     │ generate                        Generate cryptographic keys using the `securesystemslib` library                                 │
     ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 
-Key Generation (``generate``)
------------------------------
 
 .. rstuf-cli-key-generate
+
+Key Generation (``generate``)
+-----------------------------
 
 This command will generate cryptographic keys using the ``securesystemslib`` library.
 The user is requested to provide:


### PR DESCRIPTION
I noticed that the correct usage for the anchors is before the titles rather than after.

It will make the documentation more precise to use import `start-after` and `end-before`.