### PR TITLE
Add parameter `--no-auth` to the CLI

### DIFF
--- a/repository_service_tuf/cli/__init__.py
+++ b/repository_service_tuf/cli/__init__.py
@@ -9,10 +9,13 @@ import re
 from pathlib import Path
 
 import rich_click as click  # type: ignore
+from rich.console import Console
+from rich.panel import Panel
 
 from repository_service_tuf import Dynaconf
 from repository_service_tuf.__version__ import version
 
+console = Console()
 HOME = str(Path.home())
 
 # attempt to find the program name from pyproject.toml or give a default
@@ -39,17 +42,37 @@ except FileNotFoundError:
     help="Repository Service for TUF config file",
     required=False,
 )
+@click.option(
+    "--no-auth",
+    "auth",
+    help="Skips use RSTUF built-in Authentication",
+    is_flag=True,
+    default=True,
+    required=False,
+)
 # adds the --version parameter
 @click.version_option(prog_name=prog_name, version=version)
 @click.pass_context
-def rstuf(context, config):
+def rstuf(context, config, auth):
     """
     Repository Service for TUF Command Line Interface (CLI).
     """
     context.obj = {
         "settings": Dynaconf(settings_files=[config]),
         "config": config,
+        "auth": auth,
     }
+    settings = context.obj["settings"]
+    if auth is False:
+        console.print(
+            Panel(
+                "[white]Skipping RSTUF authentication (--no-auth)[/]",
+                title="[green]Info[/]",
+                title_align="left",
+                style="green",
+            )
+        )
+    settings.AUTH = auth
 
 
 # Register all command groups

--- a/repository_service_tuf/cli/__init__.py
+++ b/repository_service_tuf/cli/__init__.py
@@ -6,6 +6,7 @@ import importlib
 import os
 import pkgutil
 import re
+import sys
 from pathlib import Path
 
 import rich_click as click  # type: ignore
@@ -39,13 +40,13 @@ except FileNotFoundError:
     "--config",
     "config",
     default=os.path.join(HOME, ".rstuf.ini"),
-    help="Repository Service for TUF config file",
+    help="Repository Service for TUF config file.",
     required=False,
 )
 @click.option(
     "--no-auth",
     "auth",
-    help="Skips use RSTUF built-in Authentication",
+    help="Skips the use of RSTUF built-in authentication.",
     is_flag=True,
     default=True,
     required=False,
@@ -76,7 +77,14 @@ def rstuf(context, config, auth):
 
 
 # Register all command groups
+groups_required_auth = [
+    "repository_service_tuf.cli.admin.token",
+    "repository_service_tuf.cli.admin.login",
+]
 for _, name, _ in pkgutil.walk_packages(  # type: ignore
     __path__, prefix=__name__ + "."
 ):
-    importlib.import_module(name)
+    if name in groups_required_auth and "--no-auth" in sys.argv:
+        continue
+    else:
+        importlib.import_module(name)

--- a/repository_service_tuf/cli/admin/ceremony.py
+++ b/repository_service_tuf/cli/admin/ceremony.py
@@ -10,7 +10,6 @@ import os
 from typing import Any, Dict, Generator, Optional
 
 from rich import box, markdown, prompt, table  # type: ignore
-from rich.console import Console  # type: ignore
 from securesystemslib.exceptions import (  # type: ignore
     CryptoError,
     Error,
@@ -21,7 +20,7 @@ from securesystemslib.interface import (  # type: ignore
     import_privatekey_from_file,
 )
 
-from repository_service_tuf.cli import click
+from repository_service_tuf.cli import click, console
 from repository_service_tuf.cli.admin import admin
 from repository_service_tuf.constants import KeyType
 from repository_service_tuf.helpers.api_client import (
@@ -232,8 +231,6 @@ In this example here is how they will be distributed:
 - "1.bins-5.json" will be responsible for file:
  https://example.com/downloads/productB/updates/servicepack-1.tar
 """
-
-console = Console()
 
 
 # Define all initial settings

--- a/repository_service_tuf/cli/admin/ceremony.py
+++ b/repository_service_tuf/cli/admin/ceremony.py
@@ -687,6 +687,12 @@ def _run_ceremony_steps(save: bool) -> Dict[str, Any]:
     is_flag=True,
 )
 @click.option(
+    "--upload-server",
+    help="[when using '--no-auth'] Upload RSTUF API Server address. ",
+    required=False,
+    hidden=True,
+)
+@click.option(
     "-s",
     "--save",
     help=(
@@ -699,7 +705,12 @@ def _run_ceremony_steps(save: bool) -> Dict[str, Any]:
 )
 @click.pass_context
 def ceremony(
-    context: Any, bootstrap: bool, file: str, upload: bool, save: bool
+    context: Any,
+    bootstrap: bool,
+    file: str,
+    upload: bool,
+    save: bool,
+    upload_server: str,
 ) -> None:
     """
     Start a new Metadata Ceremony.
@@ -718,6 +729,14 @@ def ceremony(
 
     # option bootstrap: checks if the server accepts it beforehand
     if bootstrap:
+        if settings.AUTH is False and upload_server is None:
+            raise click.ClickException(
+                "Requires '--upload-server' when using '--no-auth'. "
+                "Example: --upload-server https://rstuf-api.example.com"
+            )
+        else:
+            settings.SERVER = upload_server
+
         bs_status = bootstrap_status(settings)
         if bs_status.get("data", {}).get("bootstrap") is True:
             raise click.ClickException(f"{bs_status.get('message')}")

--- a/repository_service_tuf/cli/admin/import_targets.py
+++ b/repository_service_tuf/cli/admin/import_targets.py
@@ -3,10 +3,9 @@ import os
 from datetime import datetime
 from typing import Any, Dict, List
 
-from rich.console import Console
 from tuf.api.metadata import Delegations, SuccinctRoles, Targets
 
-from repository_service_tuf.cli import click
+from repository_service_tuf.cli import click, console
 from repository_service_tuf.cli.admin import admin
 from repository_service_tuf.helpers.api_client import (
     Methods,
@@ -16,8 +15,6 @@ from repository_service_tuf.helpers.api_client import (
     task_status,
 )
 from repository_service_tuf.helpers.tuf import Metadata
-
-console = Console()
 
 
 def _check_csv_files(csv_files: List[str]):

--- a/repository_service_tuf/cli/admin/token.py
+++ b/repository_service_tuf/cli/admin/token.py
@@ -1,10 +1,7 @@
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT
-
-import click
-from rich.console import Console  # type: ignore
-
+from repository_service_tuf.cli import click, console
 from repository_service_tuf.cli.admin import admin
 from repository_service_tuf.helpers.api_client import (
     URL,
@@ -13,8 +10,6 @@ from repository_service_tuf.helpers.api_client import (
     request_server,
 )
 
-console = Console()
-
 
 @admin.group()
 @click.pass_context
@@ -22,6 +17,10 @@ def token(context):
     """
     Token Management.
     """
+    settings = context.obj.get("settings")
+    if settings.get("AUTH") is False:
+        console.print("[INFO] admin token is disabled with `--no-auth`")
+        raise click.Abort()
 
 
 @token.command()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ from repository_service_tuf.helpers.tuf import (
 def test_context() -> Dict[str, Any]:
     setting_file = os.path.join(TemporaryDirectory().name, "test_settings.ini")
     test_settings = Dynaconf(settings_files=[setting_file])
+    test_settings.AUTH = True
     return {"settings": test_settings, "config": setting_file}
 
 

--- a/tests/unit/cli/test__init__.py
+++ b/tests/unit/cli/test__init__.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2022-2023 VMware Inc
+#
+# SPDX-License-Identifier: MIT
+
+from repository_service_tuf.__version__ import version
+from repository_service_tuf.cli import rstuf
+
+
+class TestRSTUFCLI:
+    def test_tuf_repository_service(self, client):
+        test_result = client.invoke(rstuf)
+        assert test_result.exit_code == 0
+
+    def test_version_parameter(self, client):
+        """Tests the CLI --version parameter existence and output format."""
+
+        result = client.invoke(rstuf, ["--version"])
+
+        assert result.exit_code == 0
+        assert result.output == f"rstuf, version {version}\n"
+
+    def test_no_auth_parameter(self, client):
+        result = client.invoke(rstuf, ["--no-auth", "admin"])
+        assert result.exit_code == 0
+        assert "Skipping RSTUF authentication (--no-auth)" in result.output

--- a/tests/unit/helpers/test_api_client.py
+++ b/tests/unit/helpers/test_api_client.py
@@ -171,8 +171,6 @@ class TestAPIClient:
         ]
 
     def test_get_headers_no_auth(self, test_context):
-        test_context["settings"].SERVER = "http://server"
-        test_context["settings"].TOKEN = "fake_token"
         test_context["settings"].AUTH = False
         result = api_client.get_headers(test_context["settings"])
 

--- a/tests/unit/helpers/test_api_client.py
+++ b/tests/unit/helpers/test_api_client.py
@@ -69,7 +69,7 @@ class TestAPIClient:
 
         assert "Failed to connect to http://server" in str(err.value)
 
-    def test_is_logged(self):
+    def test_is_logged(self, test_context):
         fake_response = pretend.stub(
             status_code=200,
             json=pretend.call_recorder(lambda: {"data": {"expired": False}}),
@@ -78,7 +78,9 @@ class TestAPIClient:
             lambda *a, **kw: fake_response
         )
 
-        result = api_client.is_logged("http://server", "fake_token")
+        test_context["settings"].SERVER = "http://server"
+        test_context["settings"].TOKEN = "fake_token"
+        result = api_client.is_logged(test_context["settings"])
         assert result == api_client.Login(state=True, data={"expired": False})
         assert api_client.request_server.calls == [
             pretend.call(
@@ -89,7 +91,14 @@ class TestAPIClient:
             )
         ]
 
-    def test_is_logged_401(self):
+    def test_is_logged_no_auth(self, test_context):
+        test_context["settings"].SERVER = "http://server"
+        test_context["settings"].TOKEN = "fake_token"
+        test_context["settings"].AUTH = False
+        result = api_client.is_logged(test_context["settings"])
+        assert result is None
+
+    def test_is_logged_401(self, test_context):
         fake_response = pretend.stub(
             status_code=401,
         )
@@ -97,7 +106,9 @@ class TestAPIClient:
             lambda *a, **kw: fake_response
         )
 
-        result = api_client.is_logged("http://server", "fake_token")
+        test_context["settings"].SERVER = "http://server"
+        test_context["settings"].TOKEN = "fake_token"
+        result = api_client.is_logged(test_context["settings"])
         assert result == api_client.Login(state=False, data=None)
         assert api_client.request_server.calls == [
             pretend.call(
@@ -108,7 +119,7 @@ class TestAPIClient:
             )
         ]
 
-    def test_is_logged_500(self):
+    def test_is_logged_500(self, test_context):
         fake_response = pretend.stub(
             status_code=500,
             text="body",
@@ -117,8 +128,10 @@ class TestAPIClient:
             lambda *a, **kw: fake_response
         )
 
+        test_context["settings"].SERVER = "http://server"
+        test_context["settings"].TOKEN = "fake_token"
         with pytest.raises(api_client.click.ClickException) as err:
-            api_client.is_logged("http://server", "fake_token")
+            api_client.is_logged(test_context["settings"])
 
         assert "Error 500 body" in str(err)
         assert api_client.request_server.calls == [
@@ -130,7 +143,7 @@ class TestAPIClient:
             )
         ]
 
-    def test_get_headers(self):
+    def test_get_headers(self, test_context):
         api_client.is_logged = pretend.call_recorder(
             lambda *a: api_client.Login(
                 state=True, data={"data": {"expired": False}}
@@ -140,13 +153,13 @@ class TestAPIClient:
             lambda *a, **kw: pretend.stub(status_code=200)
         )
 
-        result = api_client.get_headers(
-            {"SERVER": "http://server", "TOKEN": "fake_token"}
-        )
+        test_context["settings"].SERVER = "http://server"
+        test_context["settings"].TOKEN = "fake_token"
+        result = api_client.get_headers(test_context["settings"])
 
         assert result == {"Authorization": "Bearer fake_token"}
         assert api_client.is_logged.calls == [
-            pretend.call("http://server", "fake_token")
+            pretend.call(test_context["settings"])
         ]
         assert api_client.request_server.calls == [
             pretend.call(
@@ -157,57 +170,68 @@ class TestAPIClient:
             )
         ]
 
+    def test_get_headers_no_auth(self, test_context):
+        test_context["settings"].SERVER = "http://server"
+        test_context["settings"].TOKEN = "fake_token"
+        test_context["settings"].AUTH = False
+        result = api_client.get_headers(test_context["settings"])
+
+        assert result == {}
+
     def test_get_headers_never_logged(self):
         with pytest.raises(api_client.click.ClickException) as err:
             api_client.get_headers({})
 
         assert "Login first. Run 'rstuf admin login'" in str(err)
 
-    def test_get_headers_is_logged_state_false(self):
+    def test_get_headers_is_logged_state_false(self, test_context):
         api_client.is_logged = pretend.call_recorder(
             lambda *a: api_client.Login(state=False, data={"expired": False})
         )
 
+        test_context["settings"].SERVER = "http://server"
+        test_context["settings"].TOKEN = "fake_token"
         with pytest.raises(api_client.click.ClickException) as err:
-            api_client.get_headers(
-                {"SERVER": "http://server", "TOKEN": "fake_token"}
-            )
+            api_client.get_headers(test_context["settings"])
 
         assert "re-login" in str(err)
         assert api_client.is_logged.calls == [
-            pretend.call("http://server", "fake_token")
+            pretend.call(test_context["settings"])
         ]
 
-    def test_get_headers_is_logged_state_true_expired_token(self):
+    def test_get_headers_is_logged_state_true_expired_token(
+        self, test_context
+    ):
         api_client.is_logged = pretend.call_recorder(
             lambda *a: api_client.Login(state=True, data={"expired": True})
         )
 
+        test_context["settings"].SERVER = "http://server"
+        test_context["settings"].TOKEN = "fake_token"
         with pytest.raises(api_client.click.ClickException) as err:
-            api_client.get_headers(
-                {"SERVER": "http://server", "TOKEN": "fake_token"}
-            )
+            api_client.get_headers(test_context["settings"])
 
         assert "The token has expired" in str(err)
         assert api_client.is_logged.calls == [
-            pretend.call("http://server", "fake_token")
+            pretend.call(test_context["settings"])
         ]
 
-    def test_get_headers_unexpected_error(self):
+    def test_get_headers_unexpected_error(self, test_context):
         api_client.is_logged = pretend.call_recorder(
             lambda *a: api_client.Login(state=True, data={"expired": False})
         )
         api_client.request_server = pretend.call_recorder(
             lambda *a, **kw: pretend.stub(status_code=500, text="error body")
         )
+
+        test_context["settings"].SERVER = "http://server"
+        test_context["settings"].TOKEN = "fake_token"
         with pytest.raises(api_client.click.ClickException) as err:
-            api_client.get_headers(
-                {"SERVER": "http://server", "TOKEN": "fake_token"}
-            )
+            api_client.get_headers(test_context["settings"])
 
         assert "Unexpected error" in str(err)
         assert api_client.is_logged.calls == [
-            pretend.call("http://server", "fake_token")
+            pretend.call(test_context["settings"])
         ]
 
     def test_bootstrap_status(self, test_context):


### PR DESCRIPTION
This adds the `rstuf --no-auth` parameter.

This parameter skips authentication checks/routines when communicating with RSTUF API. This makes RSTUF CLI compatible when the user disables RSTUF API built-in authentication.

Added a small refactoring about using the rich console and shared calls in the helper.
Added refactoring for the CLI init test file.

Closes #251 