### PR TITLE
fix: option --no-auth breaking --upload with auth

### DIFF
--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -24,6 +24,7 @@ Using pip:
 
     ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
     │ --config   -c  TEXT  Repository Service for TUF config file                                                                      │
+    │ --no-auth            Skips the use of RSTUF built-in authentication.                                                             │
     │ --version            Show the version and exit.                                                                                  │
     │ --help     -h        Show this message and exit.                                                                                 │
     ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

--- a/repository_service_tuf/cli/admin/ceremony.py
+++ b/repository_service_tuf/cli/admin/ceremony.py
@@ -734,7 +734,7 @@ def ceremony(
                 "Requires '--upload-server' when using '--no-auth'. "
                 "Example: --upload-server https://rstuf-api.example.com"
             )
-        else:
+        elif upload_server:
             settings.SERVER = upload_server
 
         bs_status = bootstrap_status(settings)

--- a/tests/unit/cli/admin/test_ceremony.py
+++ b/tests/unit/cli/admin/test_ceremony.py
@@ -708,6 +708,7 @@ class TestCeremonyOptions:
         )
         ceremony.task_status = pretend.call_recorder(lambda *a: None)
 
+        test_context["settings"].SERVER = "http://server"
         test_result = client.invoke(
             ceremony.ceremony,
             ["--bootstrap", "--upload"],
@@ -734,6 +735,8 @@ class TestCeremonyOptions:
                 "fake_task_id", test_context["settings"], "Bootstrap status: "
             )
         ]
+        # test regression https://github.com/vmware/repository-service-tuf-cli/pull/259  # noqa
+        assert test_context["settings"].SERVER is not None
 
     def test_ceremony_option_bootstrap_upload_no_auth(
         self, client, test_context

--- a/tests/unit/cli/admin/test_ceremony.py
+++ b/tests/unit/cli/admin/test_ceremony.py
@@ -735,6 +735,67 @@ class TestCeremonyOptions:
             )
         ]
 
+    def test_ceremony_option_bootstrap_upload_no_auth(
+        self, client, test_context
+    ):
+        ceremony.bootstrap_status = pretend.call_recorder(
+            lambda *a: {"data": {"bootstrap": False}}
+        )
+        ceremony._load_bootstrap_payload = pretend.call_recorder(
+            lambda *a: {"k": "v"}
+        )
+        ceremony._send_bootstrap = pretend.call_recorder(
+            lambda *a: "fake_task_id"
+        )
+        ceremony.task_status = pretend.call_recorder(lambda *a: None)
+
+        test_context["settings"].AUTH = False
+
+        test_result = client.invoke(
+            ceremony.ceremony,
+            ["--bootstrap", "--upload", "--upload-server", "http://rstuf"],
+            input=None,
+            obj=test_context,
+        )
+
+        assert test_result.exit_code == 0, test_result.output
+        assert (
+            "Bootstrap completed using `payload.json`. 🔐 🎉"
+            in test_result.output
+        )
+        assert ceremony.bootstrap_status.calls == [
+            pretend.call(test_context["settings"])
+        ]
+        assert ceremony._load_bootstrap_payload.calls == [
+            pretend.call("payload.json")
+        ]
+        assert ceremony._send_bootstrap.calls == [
+            pretend.call(test_context["settings"], {"k": "v"})
+        ]
+        assert ceremony.task_status.calls == [
+            pretend.call(
+                "fake_task_id", test_context["settings"], "Bootstrap status: "
+            )
+        ]
+
+    def test_ceremony_option_bootstrap_upload_no_auth_missing_upload_server(
+        self, client, test_context
+    ):
+        test_context["settings"].AUTH = False
+
+        test_result = client.invoke(
+            ceremony.ceremony,
+            ["--bootstrap", "--upload"],
+            input=None,
+            obj=test_context,
+        )
+
+        assert test_result.exit_code == 1, test_result.output
+        assert (
+            "Requires '--upload-server' when using '--no-auth'"
+            in test_result.output
+        )
+
     def test_ceremony_option_upload_missing_bootstrap(
         self, client, test_context, test_inputs, test_setup
     ):


### PR DESCRIPTION
    fix: option --no-auth breaking --upload with auth
    
    This fixes the logic behind `--no-auth` and `--upload` requiring
    `--upload-server`.
    
    When the user doesn't use `--no-auth`, but uses `--upload` the current
    logic was overwitting the server defined by `rstuf admin login`.
    
    Added tests to prevent regression
    